### PR TITLE
refactor(*): replace db injection to support transactions on unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,14 +78,9 @@ dump-schema:
 setup-test:
 	go run test-setup/main.go
 
-run-tests t: generate-queries setup-test test-rpcs test-middleware test-service test-permission test-errors test-message test-producer test-helpers test-faults test-logging test-qx
-
 
 all-tests: setup-test
-	# Note: this is not well set up tests have errors. Issue lies on how db connection is used. needs to be fixed
-	# most likely need to add a lock to the db connection( somehow )
-	# For now use run-tests command
-	go test -cover ./... | grep -v 'testutil'
+	@go test -cover ./... | grep -v 'testutil' | grep -v 'src/protos' | grep -v 'mist/src/psql_db/db'
 
 tbreak:
 	go test ./... -run "$(t)"

--- a/src/main.go
+++ b/src/main.go
@@ -16,7 +16,6 @@ import (
 	"mist/src/producer"
 	"mist/src/producer/mist_redis"
 	"mist/src/psql_db/db"
-	"mist/src/psql_db/qx"
 	"mist/src/rpcs"
 )
 
@@ -46,11 +45,11 @@ func InitializeServer(redisClient *redis.Client) {
 	}
 
 	// Create a new gRPC server with the interceptors
+
 	s := grpc.NewServer(interceptors)
 	// Register the gRPC services
 	rpcs.RegisterGrpcServices(s, &rpcs.GrpcDependencies{
-		DbConn:    dbConn,
-		Db:        db.NewQuerier(qx.New(dbConn)),
+		Db:        db.NewQuerier(dbConn),
 		MProducer: producer.NewMProducer(redisClient),
 	})
 

--- a/src/permission/appserver_role_sub_test.go
+++ b/src/permission/appserver_role_sub_test.go
@@ -13,7 +13,6 @@ import (
 	"mist/src/faults"
 	"mist/src/middleware"
 	"mist/src/permission"
-	"mist/src/psql_db/db"
 	"mist/src/psql_db/qx"
 	"mist/src/testutil"
 	"mist/src/testutil/factory"
@@ -21,8 +20,7 @@ import (
 
 func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 	var (
-		err         error
-		roleSubAuth = permission.NewAppserverRoleSubAuthorizer(db.NewQuerier(testutil.TestDbConn))
+		err error
 	)
 
 	t.Run("ActionRead", func(t *testing.T) {
@@ -36,7 +34,7 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 			})
 
 			// ACT
-			err = roleSubAuth.Authorize(ctx, nil, permission.ActionRead)
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, nil, permission.ActionRead)
 
 			// ASSERT
 			assert.Nil(t, err)
@@ -52,7 +50,7 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 			})
 
 			// ACT
-			err = roleSubAuth.Authorize(ctx, nil, permission.ActionRead)
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, nil, permission.ActionRead)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -61,167 +59,166 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 		})
 	})
 	t.Run("ActionWrite", func(t *testing.T) {
-		t.Run(permission.SubActionCreate, func(t *testing.T) {
 
-			t.Run("Success:owner_can_create_role_sub", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t, ctx, db)
+		t.Run("Success:owner_can_create_role_sub", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverOwner(t, ctx, db)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-
-				// ACT
-				err = roleSubAuth.Authorize(ctx, nil, permission.ActionCreate)
-
-				// ASSERT
-				assert.Nil(t, err)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Success:user_with_permission_can_create_role_sub", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
+			// ACT
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, nil, permission.ActionCreate)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ACT
-				err = roleSubAuth.Authorize(ctx, nil, permission.ActionWrite)
+		t.Run("Success:user_with_permission_can_create_role_sub", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
 
-				// ASSERT
-				assert.Nil(t, err)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Error:subscribed_user_cannot_create_role_sub", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t, ctx, db)
+			// ACT
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, nil, permission.ActionWrite)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ACT
-				err = roleSubAuth.Authorize(ctx, nil, permission.ActionWrite)
+		t.Run("Error:subscribed_user_cannot_create_role_sub", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "is not authorized to perform this action")
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Error:unsubscribed_user_cannot_create_role_sub", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t, ctx, db)
+			// ACT
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, nil, permission.ActionWrite)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "is not authorized to perform this action")
+		})
 
-				// ACT
-				err = roleSubAuth.Authorize(ctx, nil, permission.ActionWrite)
+		t.Run("Error:unsubscribed_user_cannot_create_role_sub", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverUnsub(t, ctx, db)
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "is not authorized to perform this action")
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+
+			// ACT
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, nil, permission.ActionWrite)
+
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "is not authorized to perform this action")
 		})
 	})
 
 	t.Run("ActionDelete", func(t *testing.T) {
-		t.Run(permission.SubActionDelete, func(t *testing.T) {
 
-			t.Run("Success:owner_can_delete_role_sub", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				roleSub := testutil.TestAppserverRoleSub(t, nil, true)
-				tu := factory.UserAppserverOwner(t, ctx, db)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				idStr := roleSub.ID.String()
-
-				// ACT
-				err = roleSubAuth.Authorize(ctx, &idStr, permission.ActionDelete)
-
-				// ASSERT
-				assert.Nil(t, err)
+		t.Run("Success:owner_can_delete_role_sub", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverOwner(t, ctx, db)
+			roleSub := factory.NewFactory(ctx, db).AppserverRoleSub(t, 0, nil)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			idStr := roleSub.ID.String()
 
-			t.Run("Success:user_with_permission_role_can_delete_role_sub", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
-				user := testutil.TestAppuser(t, nil, false)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "foo", AppserverID: tu.Server.ID}, false)
-				sub := testutil.TestAppserverSub(t, &qx.AppserverSub{AppuserID: user.ID, AppserverID: tu.Server.ID}, false)
-				roleSub := testutil.TestAppserverRoleSub(t, &qx.AppserverRoleSub{
-					AppuserID:       user.ID,
-					AppserverRoleID: role.ID,
-					AppserverSubID:  sub.ID,
-					AppserverID:     tu.Server.ID,
-				}, false)
-				idStr := roleSub.ID.String()
+			// ACT
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				// ACT
-				err = roleSubAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ASSERT
-				assert.Nil(t, err)
+		t.Run("Success:user_with_permission_role_can_delete_role_sub", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
+			f := factory.NewFactory(ctx, db)
+			user2 := f.Appuser(t, 2, &qx.Appuser{ID: uuid.New(), Username: "testuser2"})
+			sub := f.AppserverSub(t, 2, &qx.AppserverSub{AppserverID: tu.Server.ID, AppuserID: user2.ID})
+			role := f.AppserverRole(t, 1, &qx.AppserverRole{Name: "boo", AppserverID: tu.Server.ID})
+			roleSub := f.AppserverRoleSub(t, 2, &qx.AppserverRoleSub{
+				AppserverID:     tu.Server.ID,
+				AppuserID:       sub.AppuserID,
+				AppserverRoleID: role.ID,
+				AppserverSubID:  sub.ID,
 			})
+			idStr := roleSub.ID.String()
 
-			t.Run("Error:subscribed_user_without_permission_cannot_delete_role_sub", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t, ctx, db)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				roleSub := testutil.TestAppserverRoleSub(t, nil, false)
-				idStr := roleSub.ID.String()
-
-				// ACT
-				err = roleSubAuth.Authorize(ctx, &idStr, permission.ActionDelete)
-
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "is not authorized to perform this action")
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			// ACT
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-			t.Run("Error:unsubscribed_user_cannot_delete_role_sub", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t, ctx, db)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				roleSub := testutil.TestAppserverRoleSub(t, nil, false)
-				idStr := roleSub.ID.String()
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ACT
-				err = roleSubAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+		t.Run("Error:subscribed_user_without_permission_cannot_delete_role_sub", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
+			roleSub := factory.NewFactory(ctx, db).AppserverRoleSub(t, 0, nil)
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "is not authorized to perform this action")
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			idStr := roleSub.ID.String()
+
+			// ACT
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
+
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "is not authorized to perform this action")
+		})
+
+		t.Run("Error:unsubscribed_user_cannot_delete_role_sub", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverUnsub(t, ctx, db)
+			roleSub := factory.NewFactory(ctx, db).AppserverRoleSub(t, 1, nil)
+
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
+			})
+			idStr := roleSub.ID.String()
+
+			// ACT
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
+
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "is not authorized to perform this action")
 		})
 	})
 
 	t.Run("Errors", func(t *testing.T) {
 		t.Run("Error:invalid_userid_in_context", func(t *testing.T) {
 			// ARRANGE
-			ctx, _ := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			_, claims := testutil.CreateJwtToken(t, &testutil.CreateTokenParams{
 				Iss:       os.Getenv("MIST_API_JWT_ISSUER"),
 				Aud:       []string{os.Getenv("MIST_API_JWT_AUDIENCE")},
@@ -231,7 +228,7 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 			badCtx := context.WithValue(ctx, middleware.JwtClaimsK, claims)
 
 			// ACT
-			err = roleSubAuth.Authorize(badCtx, nil, permission.ActionRead)
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(badCtx, nil, permission.ActionRead)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -241,19 +238,18 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_sub_check", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t, ctx, db)
+			ctx, _ := testutil.Setup(t, func() {})
+			serverId := uuid.New()
 			idStr := uuid.New().String()
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
+				AppserverId: serverId,
 			})
 
 			mockQuerier := new(testutil.MockQuerier)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockroleSubAuth := permission.NewAppserverRoleSubAuthorizer(mockQuerier)
 
 			// ACT
-			err = mockroleSubAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			err = permission.NewAppserverRoleSubAuthorizer(mockQuerier).Authorize(ctx, &idStr, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -264,32 +260,32 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_server_search", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
-			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
+			ctx, _ := testutil.Setup(t, func() {})
+			userId := uuid.New()
+			serverId := uuid.New()
+			subId := uuid.New()
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
+				AppserverId: serverId,
 			})
 			idStr := uuid.New().String()
 
+			mockQuerier := new(testutil.MockQuerier)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
-					ID:          tu.Sub.ID,
-					AppserverID: tu.Server.ID,
-					AppuserID:   tu.User.ID,
+					ID:          subId,
+					AppserverID: serverId,
+					AppuserID:   userId,
 				},
 			}, nil)
 			mockQuerier.On("GetAppserverRoleSubById", mock.Anything, mock.Anything).Return(qx.AppserverRoleSub{
-				ID:          tu.Sub.ID,
-				AppserverID: tu.Server.ID,
-				AppuserID:   tu.User.ID,
+				ID:          subId,
+				AppserverID: serverId,
+				AppuserID:   userId,
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
 
-			mockroleSubAuth := permission.NewAppserverRoleSubAuthorizer(mockQuerier)
-
 			// ACT
-			err = mockroleSubAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			err = permission.NewAppserverRoleSubAuthorizer(mockQuerier).Authorize(ctx, &idStr, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -300,35 +296,36 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_user_permission_mask", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
-			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
+			ctx, _ := testutil.Setup(t, func() {})
+			userId := uuid.New()
+			serverId := uuid.New()
+			subId := uuid.New()
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
+				AppserverId: serverId,
 			})
 			idStr := uuid.New().String()
 
+			mockQuerier := new(testutil.MockQuerier)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
-					ID:          tu.Sub.ID,
-					AppserverID: tu.Server.ID,
-					AppuserID:   tu.User.ID,
+					ID:          subId,
+					AppserverID: serverId,
+					AppuserID:   userId,
 				},
 			}, nil)
 			mockQuerier.On("GetAppserverRoleSubById", mock.Anything, mock.Anything).Return(qx.AppserverRoleSub{
-				ID:          tu.Sub.ID,
-				AppuserID:   tu.User.ID,
-				AppserverID: tu.Server.ID,
+				ID:          subId,
+				AppuserID:   userId,
+				AppserverID: serverId,
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(qx.Appserver{
-				ID:        tu.Server.ID,
-				AppuserID: tu.Server.AppuserID,
+				ID:        serverId,
+				AppuserID: userId,
 			}, nil)
 			mockQuerier.On("GetAppuserRoles", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockroleSubAuth := permission.NewAppserverRoleSubAuthorizer(mockQuerier)
 
 			// ACT
-			err = mockroleSubAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			err = permission.NewAppserverRoleSubAuthorizer(mockQuerier).Authorize(ctx, &idStr, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -341,14 +338,13 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 			// ARRANGE
 			ctx, db := testutil.Setup(t, func() {})
 			tu := factory.UserAppserverSub(t, ctx, db)
-			testutil.TestAppserverSub(t, nil, true)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
 			badId := "invalid"
 
 			// ACT
-			err = roleSubAuth.Authorize(ctx, &badId, permission.ActionDelete)
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, &badId, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -358,12 +354,12 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_server_id_format", func(t *testing.T) {
 			// ARRANGE
-			ctx, _ := testutil.Setup(t, func() {})
-			testutil.TestAppserverSub(t, nil, true)
+			ctx, db := testutil.Setup(t, func() {})
+			factory.UserAppserverSub(t, ctx, db)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, "invalid")
 
 			// ACT
-			err = roleSubAuth.Authorize(ctx, nil, permission.ActionDelete)
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, nil, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -375,14 +371,13 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 			// ARRANGE
 			ctx, db := testutil.Setup(t, func() {})
 			tu := factory.UserAppserverSub(t, ctx, db)
-			testutil.TestAppserverSub(t, nil, true)
 			nonExistentId := uuid.NewString()
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
 
 			// ACT
-			err = roleSubAuth.Authorize(ctx, &nonExistentId, permission.ActionDelete)
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, &nonExistentId, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -400,7 +395,7 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 			var nilObj *string
 
 			// ACT
-			err = roleSubAuth.Authorize(ctx, nilObj, permission.ActionDelete)
+			err = permission.NewAppserverRoleSubAuthorizer(db).Authorize(ctx, nilObj, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)

--- a/src/permission/appserver_role_sub_test.go
+++ b/src/permission/appserver_role_sub_test.go
@@ -22,14 +22,14 @@ import (
 func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 	var (
 		err         error
-		roleSubAuth = permission.NewAppserverRoleSubAuthorizer(testutil.TestDbConn, db.NewQuerier(qx.New(testutil.TestDbConn)))
+		roleSubAuth = permission.NewAppserverRoleSubAuthorizer(db.NewQuerier(testutil.TestDbConn))
 	)
 
 	t.Run("ActionRead", func(t *testing.T) {
-		t.Run("Successsubscribed_user_can_list_roles", func(t *testing.T) {
+		t.Run("Success:subscribed_user_can_list_roles", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
@@ -44,8 +44,8 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:unsubscribed_user_cannot_read", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			sub := factory.UserAppserverUnsub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			sub := factory.UserAppserverUnsub(t, ctx, db)
 
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: sub.Server.ID,
@@ -63,10 +63,10 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 	t.Run("ActionWrite", func(t *testing.T) {
 		t.Run(permission.SubActionCreate, func(t *testing.T) {
 
-			t.Run("Successowner_can_create_role_sub", func(t *testing.T) {
+			t.Run("Success:owner_can_create_role_sub", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverOwner(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -79,10 +79,10 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 				assert.Nil(t, err)
 			})
 
-			t.Run("Successuser_with_permission_can_create_role_sub", func(t *testing.T) {
+			t.Run("Success:user_with_permission_can_create_role_sub", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -97,8 +97,8 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:subscribed_user_cannot_create_role_sub", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverSub(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -115,8 +115,8 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:unsubscribed_user_cannot_create_role_sub", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverUnsub(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -136,11 +136,11 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 	t.Run("ActionDelete", func(t *testing.T) {
 		t.Run(permission.SubActionDelete, func(t *testing.T) {
 
-			t.Run("Successowner_can_delete_role_sub", func(t *testing.T) {
+			t.Run("Success:owner_can_delete_role_sub", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
+				ctx, db := testutil.Setup(t, func() {})
 				roleSub := testutil.TestAppserverRoleSub(t, nil, true)
-				tu := factory.UserAppserverOwner(t)
+				tu := factory.UserAppserverOwner(t, ctx, db)
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
 				})
@@ -153,10 +153,10 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 				assert.Nil(t, err)
 			})
 
-			t.Run("Successuser_with_permission_role_can_delete_role_sub", func(t *testing.T) {
+			t.Run("Success:user_with_permission_role_can_delete_role_sub", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
 				user := testutil.TestAppuser(t, nil, false)
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -180,8 +180,8 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:subscribed_user_without_permission_cannot_delete_role_sub", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverSub(t, ctx, db)
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
 				})
@@ -199,8 +199,8 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:unsubscribed_user_cannot_delete_role_sub", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverUnsub(t, ctx, db)
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
 				})
@@ -221,7 +221,7 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 	t.Run("Errors", func(t *testing.T) {
 		t.Run("Error:invalid_userid_in_context", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
 			_, claims := testutil.CreateJwtToken(t, &testutil.CreateTokenParams{
 				Iss:       os.Getenv("MIST_API_JWT_ISSUER"),
 				Aud:       []string{os.Getenv("MIST_API_JWT_AUDIENCE")},
@@ -241,15 +241,16 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_sub_check", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t)
-			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockroleSubAuth := permission.NewAppserverRoleSubAuthorizer(testutil.TestDbConn, mockQuerier)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
+			idStr := uuid.New().String()
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
-			idStr := uuid.New().String()
+
+			mockQuerier := new(testutil.MockQuerier)
+			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
+			mockroleSubAuth := permission.NewAppserverRoleSubAuthorizer(mockQuerier)
 
 			// ACT
 			err = mockroleSubAuth.Authorize(ctx, &idStr, permission.ActionDelete)
@@ -263,9 +264,14 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_server_search", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t)
+			tu := factory.UserAppserverSub(t, ctx, db)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
+			})
+			idStr := uuid.New().String()
+
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
 					ID:          tu.Sub.ID,
@@ -279,11 +285,8 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 				AppuserID:   tu.User.ID,
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockroleSubAuth := permission.NewAppserverRoleSubAuthorizer(testutil.TestDbConn, mockQuerier)
-			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
-			})
-			idStr := uuid.New().String()
+
+			mockroleSubAuth := permission.NewAppserverRoleSubAuthorizer(mockQuerier)
 
 			// ACT
 			err = mockroleSubAuth.Authorize(ctx, &idStr, permission.ActionDelete)
@@ -297,9 +300,14 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_user_permission_mask", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t)
+			tu := factory.UserAppserverSub(t, ctx, db)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
+			})
+			idStr := uuid.New().String()
+
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
 					ID:          tu.Sub.ID,
@@ -317,11 +325,7 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 				AppuserID: tu.Server.AppuserID,
 			}, nil)
 			mockQuerier.On("GetAppuserRoles", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockroleSubAuth := permission.NewAppserverRoleSubAuthorizer(testutil.TestDbConn, mockQuerier)
-			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
-			})
-			idStr := uuid.New().String()
+			mockroleSubAuth := permission.NewAppserverRoleSubAuthorizer(mockQuerier)
 
 			// ACT
 			err = mockroleSubAuth.Authorize(ctx, &idStr, permission.ActionDelete)
@@ -335,8 +339,8 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_object_id_format", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 			testutil.TestAppserverSub(t, nil, true)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
@@ -354,7 +358,7 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_server_id_format", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
 			testutil.TestAppserverSub(t, nil, true)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, "invalid")
 
@@ -369,8 +373,8 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:object_id_not_found", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 			testutil.TestAppserverSub(t, nil, true)
 			nonExistentId := uuid.NewString()
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
@@ -387,8 +391,8 @@ func TestAppserverRoleSubAuthorizer_Authorize(t *testing.T) {
 		})
 
 		t.Run("Error:nil_object_errors", func(t *testing.T) {
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})

--- a/src/permission/appserver_role_test.go
+++ b/src/permission/appserver_role_test.go
@@ -13,7 +13,6 @@ import (
 	"mist/src/faults"
 	"mist/src/middleware"
 	"mist/src/permission"
-	"mist/src/psql_db/db"
 	"mist/src/psql_db/qx"
 	"mist/src/testutil"
 	"mist/src/testutil/factory"
@@ -21,8 +20,7 @@ import (
 
 func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 	var (
-		err      error
-		roleAuth = permission.NewAppserverRoleAuthorizer(db.NewQuerier(testutil.TestDbConn))
+		err error
 	)
 
 	t.Run("ActionRead", func(t *testing.T) {
@@ -36,7 +34,7 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 			})
 
 			// ACT
-			err = roleAuth.Authorize(ctx, nil, permission.ActionRead)
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionRead)
 
 			// ASSERT
 			assert.Nil(t, err)
@@ -52,7 +50,7 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 			})
 
 			// ACT
-			err = roleAuth.Authorize(ctx, nil, permission.ActionRead)
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionRead)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -62,159 +60,156 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 	})
 
 	t.Run("ActionWrite", func(t *testing.T) {
-		t.Run(permission.SubActionCreate, func(t *testing.T) {
 
-			t.Run("Success:owner_can_create_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t, ctx, db)
+		t.Run("Success:owner_can_create_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverOwner(t, ctx, db)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-
-				// ACT
-				err = roleAuth.Authorize(ctx, nil, permission.ActionCreate)
-
-				// ASSERT
-				assert.Nil(t, err)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Success:user_with_appserver_permission_can_create_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
+			// ACT
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionCreate)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ACT
-				err = roleAuth.Authorize(ctx, nil, permission.ActionWrite)
+		t.Run("Success:user_with_appserver_permission_can_create_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
 
-				// ASSERT
-				assert.Nil(t, err)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Error:subscribed_user_cannot_create_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t, ctx, db)
+			// ACT
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionWrite)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ACT
-				err = roleAuth.Authorize(ctx, nil, permission.ActionWrite)
+		t.Run("Error:subscribed_user_cannot_create_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "Unauthorized")
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Error:unsubscribed_user_cannot_create_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t, ctx, db)
+			// ACT
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionWrite)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "Unauthorized")
+		})
 
-				// ACT
-				err = roleAuth.Authorize(ctx, nil, permission.ActionWrite)
+		t.Run("Error:unsubscribed_user_cannot_create_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverUnsub(t, ctx, db)
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "Unauthorized")
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+
+			// ACT
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionWrite)
+
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "Unauthorized")
 		})
 	})
 
 	t.Run("ActionDelete", func(t *testing.T) {
-		t.Run(permission.SubActionDelete, func(t *testing.T) {
 
-			t.Run("Success:owner_can_delete_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t, ctx, db)
-				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "foo", AppserverID: tu.Server.ID}, false)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				idStr := role.ID.String()
-
-				// ACT
-				err = roleAuth.Authorize(ctx, &idStr, permission.ActionDelete)
-
-				// ASSERT
-				assert.Nil(t, err)
+		t.Run("Success:owner_can_delete_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverOwner(t, ctx, db)
+			role := factory.NewFactory(ctx, db).AppserverRole(t, 0, nil)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			idStr := role.ID.String()
 
-			t.Run("Success:user_with_permission_role_can_delete_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
-				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "foo", AppserverID: tu.Server.ID}, false)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				idStr := role.ID.String()
+			// ACT
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				// ACT
-				err = roleAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ASSERT
-				assert.Nil(t, err)
+		t.Run("Success:user_with_permission_role_can_delete_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
+			role := factory.NewFactory(ctx, db).AppserverRole(t, 0, nil)
+
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			idStr := role.ID.String()
 
-			t.Run("Error:subscribed_user_without_permission_cannot_delete_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t, ctx, db)
-				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "foo", AppserverID: tu.Server.ID}, false)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				idStr := role.ID.String()
+			// ACT
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				// ACT
-				err = roleAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "Unauthorized")
+		t.Run("Error:subscribed_user_without_permission_cannot_delete_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
+			role := factory.NewFactory(ctx, db).AppserverRole(t, 0, nil)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			idStr := role.ID.String()
 
-			t.Run("Error:unsubscribed_user_cannot_delete_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t, ctx, db)
-				role := testutil.TestAppserverRole(t, nil, false)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				idStr := role.ID.String()
+			// ACT
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				// ACT
-				err = roleAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "Unauthorized")
+		})
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "Unauthorized")
+		t.Run("Error:unsubscribed_user_cannot_delete_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverUnsub(t, ctx, db)
+			role := factory.NewFactory(ctx, db).AppserverRole(t, 0, nil)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			idStr := role.ID.String()
+
+			// ACT
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
+
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "Unauthorized")
 		})
 	})
 
 	t.Run("Errors", func(t *testing.T) {
 		t.Run("Error:invalid_userid_in_context", func(t *testing.T) {
 			// ARRANGE
-			ctx, _ := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			_, claims := testutil.CreateJwtToken(t, &testutil.CreateTokenParams{
 				Iss:       os.Getenv("MIST_API_JWT_ISSUER"),
 				Aud:       []string{os.Getenv("MIST_API_JWT_AUDIENCE")},
@@ -224,7 +219,7 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 			badCtx := context.WithValue(ctx, middleware.JwtClaimsK, claims)
 
 			// ACT
-			err = roleAuth.Authorize(badCtx, nil, permission.ActionRead)
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(badCtx, nil, permission.ActionRead)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -234,15 +229,17 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_sub_check", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
-			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
-			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockRoleAuth := permission.NewAppserverRoleAuthorizer(mockQuerier)
-			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
-			})
+			ctx, _ := testutil.Setup(t, func() {})
+			serverId := uuid.New()
 			idStr := uuid.New().String()
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: serverId,
+			})
+
+			mockQuerier := new(testutil.MockQuerier)
+			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
+
+			mockRoleAuth := permission.NewAppserverRoleAuthorizer(mockQuerier)
 
 			// ACT
 			err = mockRoleAuth.Authorize(ctx, &idStr, permission.ActionDelete)
@@ -256,27 +253,31 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_server_search", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
+			userId := uuid.New()
+			serverId := uuid.New()
+			subId := uuid.New()
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: serverId,
+			})
+			idStr := uuid.New().String()
+
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
-					ID:          tu.Sub.ID,
-					AppserverID: tu.Server.ID,
-					AppuserID:   tu.User.ID,
+					ID:          subId,
+					AppserverID: serverId,
+					AppuserID:   userId,
 				},
 			}, nil)
 			mockQuerier.On("GetAppserverRoleById", mock.Anything, mock.Anything).Return(qx.AppserverRole{
-				ID:          tu.Sub.ID,
-				AppserverID: tu.Server.ID,
+				ID:          subId,
+				AppserverID: serverId,
 				Name:        "boo",
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
+
 			mockRoleAuth := permission.NewAppserverRoleAuthorizer(mockQuerier)
-			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
-			})
-			idStr := uuid.New().String()
 
 			// ACT
 			err = mockRoleAuth.Authorize(ctx, &idStr, permission.ActionDelete)
@@ -290,31 +291,35 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_user_permission_mask", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
+			userId := uuid.New()
+			serverId := uuid.New()
+			subId := uuid.New()
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: serverId,
+			})
+			idStr := uuid.New().String()
+
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
-					ID:          tu.Sub.ID,
-					AppserverID: tu.Server.ID,
-					AppuserID:   tu.User.ID,
+					ID:          subId,
+					AppserverID: serverId,
+					AppuserID:   userId,
 				},
 			}, nil)
 			mockQuerier.On("GetAppserverRoleById", mock.Anything, mock.Anything).Return(qx.AppserverRole{
-				ID:          tu.Sub.ID,
-				AppserverID: tu.Server.ID,
+				ID:          subId,
+				AppserverID: serverId,
 				Name:        "boo",
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(qx.Appserver{
-				ID:        tu.Server.ID,
-				AppuserID: tu.Server.AppuserID,
+				ID:        serverId,
+				AppuserID: userId,
 			}, nil)
 			mockQuerier.On("GetAppuserRoles", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
+
 			mockRoleAuth := permission.NewAppserverRoleAuthorizer(mockQuerier)
-			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
-			})
-			idStr := uuid.New().String()
 
 			// ACT
 			err = mockRoleAuth.Authorize(ctx, &idStr, permission.ActionDelete)
@@ -330,14 +335,13 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 			// ARRANGE
 			ctx, db := testutil.Setup(t, func() {})
 			tu := factory.UserAppserverSub(t, ctx, db)
-			testutil.TestAppserverSub(t, nil, true)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
 			badId := "invalid"
 
 			// ACT
-			err = roleAuth.Authorize(ctx, &badId, permission.ActionDelete)
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, &badId, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -347,12 +351,12 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_server_id_format", func(t *testing.T) {
 			// ARRANGE
-			ctx, _ := testutil.Setup(t, func() {})
-			testutil.TestAppserverSub(t, nil, true)
+			ctx, db := testutil.Setup(t, func() {})
+			factory.UserAppserverSub(t, ctx, db)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, "invalid")
 
 			// ACT
-			err = roleAuth.Authorize(ctx, nil, permission.ActionDelete)
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -364,14 +368,13 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 			// ARRANGE
 			ctx, db := testutil.Setup(t, func() {})
 			tu := factory.UserAppserverSub(t, ctx, db)
-			testutil.TestAppserverSub(t, nil, true)
 			nonExistentId := uuid.NewString()
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
 
 			// ACT
-			err = roleAuth.Authorize(ctx, &nonExistentId, permission.ActionDelete)
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, &nonExistentId, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -389,7 +392,7 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 			var nilObj *string
 
 			// ACT
-			err = roleAuth.Authorize(ctx, nilObj, permission.ActionDelete)
+			err = permission.NewAppserverRoleAuthorizer(db).Authorize(ctx, nilObj, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)

--- a/src/permission/appserver_role_test.go
+++ b/src/permission/appserver_role_test.go
@@ -22,14 +22,14 @@ import (
 func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 	var (
 		err      error
-		roleAuth = permission.NewAppserverRoleAuthorizer(testutil.TestDbConn, db.NewQuerier(qx.New(testutil.TestDbConn)))
+		roleAuth = permission.NewAppserverRoleAuthorizer(db.NewQuerier(testutil.TestDbConn))
 	)
 
 	t.Run("ActionRead", func(t *testing.T) {
-		t.Run("Successsubscribed_user_can_list_roles", func(t *testing.T) {
+		t.Run("Success:subscribed_user_can_list_roles", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
@@ -44,8 +44,8 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:unsubscribed_user_cannot_read", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			sub := factory.UserAppserverUnsub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			sub := factory.UserAppserverUnsub(t, ctx, db)
 
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: sub.Server.ID,
@@ -64,10 +64,10 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 	t.Run("ActionWrite", func(t *testing.T) {
 		t.Run(permission.SubActionCreate, func(t *testing.T) {
 
-			t.Run("Successowner_can_create_role", func(t *testing.T) {
+			t.Run("Success:owner_can_create_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverOwner(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -80,10 +80,10 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 				assert.Nil(t, err)
 			})
 
-			t.Run("Successuser_with_appserver_permission_can_create_role", func(t *testing.T) {
+			t.Run("Success:user_with_appserver_permission_can_create_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -98,8 +98,8 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:subscribed_user_cannot_create_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverSub(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -116,8 +116,8 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:unsubscribed_user_cannot_create_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverUnsub(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -137,10 +137,10 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 	t.Run("ActionDelete", func(t *testing.T) {
 		t.Run(permission.SubActionDelete, func(t *testing.T) {
 
-			t.Run("Successowner_can_delete_role", func(t *testing.T) {
+			t.Run("Success:owner_can_delete_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverOwner(t, ctx, db)
 				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "foo", AppserverID: tu.Server.ID}, false)
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -154,10 +154,10 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 				assert.Nil(t, err)
 			})
 
-			t.Run("Successuser_with_permission_role_can_delete_role", func(t *testing.T) {
+			t.Run("Success:user_with_permission_role_can_delete_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
 				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "foo", AppserverID: tu.Server.ID}, false)
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -173,8 +173,8 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:subscribed_user_without_permission_cannot_delete_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverSub(t, ctx, db)
 				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "foo", AppserverID: tu.Server.ID}, false)
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -192,8 +192,8 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:unsubscribed_user_cannot_delete_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverUnsub(t, ctx, db)
 				role := testutil.TestAppserverRole(t, nil, false)
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -214,7 +214,7 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 	t.Run("Errors", func(t *testing.T) {
 		t.Run("Error:invalid_userid_in_context", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
 			_, claims := testutil.CreateJwtToken(t, &testutil.CreateTokenParams{
 				Iss:       os.Getenv("MIST_API_JWT_ISSUER"),
 				Aud:       []string{os.Getenv("MIST_API_JWT_AUDIENCE")},
@@ -234,11 +234,11 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_sub_check", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t)
+			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockRoleAuth := permission.NewAppserverRoleAuthorizer(testutil.TestDbConn, mockQuerier)
+			mockRoleAuth := permission.NewAppserverRoleAuthorizer(mockQuerier)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
@@ -256,9 +256,9 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_server_search", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t)
+			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
 					ID:          tu.Sub.ID,
@@ -272,7 +272,7 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 				Name:        "boo",
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockRoleAuth := permission.NewAppserverRoleAuthorizer(testutil.TestDbConn, mockQuerier)
+			mockRoleAuth := permission.NewAppserverRoleAuthorizer(mockQuerier)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
@@ -290,9 +290,9 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_user_permission_mask", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t)
+			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
 					ID:          tu.Sub.ID,
@@ -310,7 +310,7 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 				AppuserID: tu.Server.AppuserID,
 			}, nil)
 			mockQuerier.On("GetAppuserRoles", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockRoleAuth := permission.NewAppserverRoleAuthorizer(testutil.TestDbConn, mockQuerier)
+			mockRoleAuth := permission.NewAppserverRoleAuthorizer(mockQuerier)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
@@ -328,8 +328,8 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_object_id_format", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 			testutil.TestAppserverSub(t, nil, true)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
@@ -347,7 +347,7 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_server_id_format", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
 			testutil.TestAppserverSub(t, nil, true)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, "invalid")
 
@@ -362,8 +362,8 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:object_id_not_found", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 			testutil.TestAppserverSub(t, nil, true)
 			nonExistentId := uuid.NewString()
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
@@ -380,8 +380,8 @@ func TestAppserverRoleAuthorizer_Authorize(t *testing.T) {
 		})
 
 		t.Run("Error:nil_object_errors", func(t *testing.T) {
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})

--- a/src/permission/appserver_sub_test.go
+++ b/src/permission/appserver_sub_test.go
@@ -13,7 +13,6 @@ import (
 	"mist/src/faults"
 	"mist/src/middleware"
 	"mist/src/permission"
-	"mist/src/psql_db/db"
 	"mist/src/psql_db/qx"
 	"mist/src/testutil"
 	"mist/src/testutil/factory"
@@ -21,8 +20,7 @@ import (
 
 func TestAppserverSubAuthorizer_Authorize(t *testing.T) {
 	var (
-		err     error
-		subAuth = permission.NewAppserverSubAuthorizer(db.NewQuerier(testutil.TestDbConn))
+		err error
 	)
 
 	t.Run("ActionRead", func(t *testing.T) {
@@ -38,7 +36,7 @@ func TestAppserverSubAuthorizer_Authorize(t *testing.T) {
 			})
 
 			// ACT
-			err = subAuth.Authorize(ctx, &idString, permission.ActionRead)
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(ctx, &idString, permission.ActionRead)
 
 			// ASSERT
 			assert.Nil(t, err)
@@ -55,7 +53,7 @@ func TestAppserverSubAuthorizer_Authorize(t *testing.T) {
 			})
 
 			// ACT
-			err = subAuth.Authorize(ctx, &idString, permission.ActionRead)
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(ctx, &idString, permission.ActionRead)
 
 			// ASSERT
 			assert.Nil(t, err)
@@ -71,7 +69,7 @@ func TestAppserverSubAuthorizer_Authorize(t *testing.T) {
 			})
 
 			// ACT
-			err = subAuth.Authorize(ctx, &idString, permission.ActionRead)
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(ctx, &idString, permission.ActionRead)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -81,127 +79,137 @@ func TestAppserverSubAuthorizer_Authorize(t *testing.T) {
 	})
 
 	t.Run("ActionWrite", func(t *testing.T) {
-		t.Run(permission.SubActionCreate, func(t *testing.T) {
 
-			t.Run("Success:anyone_can_create_appserver_sub", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t, ctx, db)
+		t.Run("Success:anyone_can_create_appserver_sub", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverUnsub(t, ctx, db)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-
-				// ACT
-				err = subAuth.Authorize(ctx, nil, permission.ActionCreate)
-
-				// ASSERT
-				assert.Nil(t, err)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+
+			// ACT
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(ctx, nil, permission.ActionCreate)
+
+			// ASSERT
+			assert.Nil(t, err)
 		})
 	})
 
 	t.Run("ActionDelete", func(t *testing.T) {
-		t.Run(permission.SubActionDelete, func(t *testing.T) {
-			t.Run("Success:owner_can_delete_another_user_sub", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t, ctx, db)
-				user := testutil.TestAppuser(t, nil, false)
-				sub := testutil.TestAppserverSub(t, &qx.AppserverSub{AppserverID: tu.Server.ID, AppuserID: user.ID}, false)
-				idStr := sub.ID.String()
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-
-				// ACT
-				err = subAuth.Authorize(ctx, &idStr, permission.ActionDelete)
-
-				// ASSERT
-				assert.Nil(t, err)
+		t.Run("Success:owner_can_delete_another_user_sub", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverOwner(t, ctx, db)
+			f := factory.NewFactory(ctx, db)
+			user := f.Appuser(t, 1, nil)
+			sub := f.AppserverSub(t, 1, &qx.AppserverSub{
+				AppserverID: tu.Server.ID,
+				AppuserID:   user.ID,
+			})
+			idStr := sub.ID.String()
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Error:nobody_can_delete_owner_sub", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t, ctx, db)
+			// ACT
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				idStr := tu.Sub.ID.String()
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+		t.Run("Error:nobody_can_delete_owner_sub", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverOwner(t, ctx, db)
 
-				// ACT
-				err = subAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			idStr := tu.Sub.ID.String()
 
-				// ASSERT
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "cannot delete the owner's sub")
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Error:object_owner_can_delete_its_own_subscription", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t, ctx, db)
+			// ACT
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				idStr := tu.Sub.ID.String()
+			// ASSERT
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "cannot delete the owner's sub")
+		})
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+		t.Run("Error:object_owner_can_delete_its_own_subscription", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 
-				// ACT
-				err = subAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			idStr := tu.Sub.ID.String()
 
-				// ASSERT
-				assert.Nil(t, err)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Success:user_with_delete_permission_can_delete_sub", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
-				user := testutil.TestAppuser(t, nil, false)
-				sub := testutil.TestAppserverSub(t, &qx.AppserverSub{AppserverID: tu.Server.ID, AppuserID: user.ID}, false)
+			// ACT
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				idStr := sub.ID.String()
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-
-				// ACT
-				err = subAuth.Authorize(ctx, &idStr, permission.ActionDelete)
-
-				// ASSERT
-				assert.Nil(t, err)
+		t.Run("Success:user_with_delete_permission_can_delete_sub", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
+			f := factory.NewFactory(ctx, db)
+			user := f.Appuser(t, 2, nil)
+			sub := f.AppserverSub(t, 2, &qx.AppserverSub{
+				AppserverID: tu.Server.ID,
+				AppuserID:   user.ID,
 			})
 
-			t.Run("Error:subscribed_user_without_permission_cannot_delete_other_user_sub", func(t *testing.T) {
-				// ARRANGE
-				ctx, _ := testutil.Setup(t, func() {})
-				sub := testutil.TestAppserverSub(t, nil, false)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: sub.AppserverID,
-				})
-				idStr := sub.ID.String()
+			idStr := sub.ID.String()
 
-				// ACT
-				err = subAuth.Authorize(ctx, &idStr, permission.ActionDelete)
-
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage subscriptions")
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+
+			// ACT
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
+
+			// ASSERT
+			assert.Nil(t, err)
+		})
+
+		t.Run("Error:subscribed_user_without_permission_cannot_delete_other_user_sub", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
+			f := factory.NewFactory(ctx, db)
+			user := f.Appuser(t, 2, nil)
+			sub := f.AppserverSub(t, 2, &qx.AppserverSub{
+				AppserverID: tu.Server.ID,
+				AppuserID:   user.ID,
+			})
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: sub.AppserverID,
+			})
+			idStr := sub.ID.String()
+
+			// ACT
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
+
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage subscriptions")
 		})
 	})
 
 	t.Run("Errors", func(t *testing.T) {
 		t.Run("Error:invalid_userid_in_context", func(t *testing.T) {
 			// ARRANGE
-			ctx, _ := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			_, claims := testutil.CreateJwtToken(t, &testutil.CreateTokenParams{
 				Iss:       os.Getenv("MIST_API_JWT_ISSUER"),
 				Aud:       []string{os.Getenv("MIST_API_JWT_AUDIENCE")},
@@ -211,7 +219,7 @@ func TestAppserverSubAuthorizer_Authorize(t *testing.T) {
 			badCtx := context.WithValue(ctx, middleware.JwtClaimsK, claims)
 
 			// ACT
-			err = subAuth.Authorize(badCtx, nil, permission.ActionRead)
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(badCtx, nil, permission.ActionRead)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -221,13 +229,14 @@ func TestAppserverSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_sub_check", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
+			serverId := uuid.New()
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
 			mockSubAuth := permission.NewAppserverSubAuthorizer(mockQuerier)
+
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
+				AppserverId: serverId,
 			})
 			idStr := uuid.New().String()
 
@@ -243,27 +252,31 @@ func TestAppserverSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_server_search", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
+			userId := uuid.New()
+			serverId := uuid.New()
+			subId := uuid.New()
+			idStr := uuid.New().String()
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: serverId,
+			})
+
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
-					ID:          tu.Sub.ID,
-					AppserverID: tu.Server.ID,
-					AppuserID:   tu.User.ID,
+					ID:          subId,
+					AppserverID: serverId,
+					AppuserID:   userId,
 				},
 			}, nil)
 			mockQuerier.On("GetAppserverSubById", mock.Anything, mock.Anything).Return(qx.AppserverSub{
-				ID:          tu.Sub.ID,
-				AppserverID: tu.Server.ID,
-				AppuserID:   tu.User.ID,
+				ID:          subId,
+				AppserverID: serverId,
+				AppuserID:   userId,
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
+
 			mockSubAuth := permission.NewAppserverSubAuthorizer(mockQuerier)
-			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
-			})
-			idStr := uuid.New().String()
 
 			// ACT
 			err = mockSubAuth.Authorize(ctx, &idStr, permission.ActionDelete)
@@ -277,31 +290,35 @@ func TestAppserverSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_user_permission_mask", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
+			userId := uuid.New()
+			serverId := uuid.New()
+			subId := uuid.New()
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: serverId,
+			})
+			idStr := uuid.New().String()
+
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
-					ID:          tu.Sub.ID,
-					AppserverID: tu.Server.ID,
-					AppuserID:   tu.User.ID,
+					ID:          subId,
+					AppserverID: serverId,
+					AppuserID:   userId,
 				},
 			}, nil)
 			mockQuerier.On("GetAppserverSubById", mock.Anything, mock.Anything).Return(qx.AppserverSub{
-				ID:          tu.Sub.ID,
-				AppserverID: tu.Server.ID,
-				AppuserID:   uuid.New(),
+				ID:          subId,
+				AppserverID: serverId,
+				AppuserID:   userId,
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(qx.Appserver{
-				ID:        tu.Server.ID,
-				AppuserID: tu.Server.AppuserID,
+				ID:        serverId,
+				AppuserID: uuid.New(),
 			}, nil)
 			mockQuerier.On("GetAppuserRoles", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
+
 			mockSubAuth := permission.NewAppserverSubAuthorizer(mockQuerier)
-			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
-			})
-			idStr := uuid.New().String()
 
 			// ACT
 			err = mockSubAuth.Authorize(ctx, &idStr, permission.ActionDelete)
@@ -317,14 +334,13 @@ func TestAppserverSubAuthorizer_Authorize(t *testing.T) {
 			// ARRANGE
 			ctx, db := testutil.Setup(t, func() {})
 			tu := factory.UserAppserverSub(t, ctx, db)
-			testutil.TestAppserverSub(t, nil, true)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
 			badId := "invalid"
 
 			// ACT
-			err = subAuth.Authorize(ctx, &badId, permission.ActionDelete)
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(ctx, &badId, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -334,12 +350,12 @@ func TestAppserverSubAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_server_id_format", func(t *testing.T) {
 			// ARRANGE
-			ctx, _ := testutil.Setup(t, func() {})
-			testutil.TestAppserverSub(t, nil, true)
+			ctx, db := testutil.Setup(t, func() {})
+			factory.UserAppserverSub(t, ctx, db)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, "invalid")
 
 			// ACT
-			err = subAuth.Authorize(ctx, nil, permission.ActionDelete)
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(ctx, nil, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -351,14 +367,13 @@ func TestAppserverSubAuthorizer_Authorize(t *testing.T) {
 			// ARRANGE
 			ctx, db := testutil.Setup(t, func() {})
 			tu := factory.UserAppserverSub(t, ctx, db)
-			testutil.TestAppserverSub(t, nil, true)
 			nonExistentId := uuid.NewString()
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
 
 			// ACT
-			err = subAuth.Authorize(ctx, &nonExistentId, permission.ActionDelete)
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(ctx, &nonExistentId, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -376,7 +391,7 @@ func TestAppserverSubAuthorizer_Authorize(t *testing.T) {
 			var nilObj *string
 
 			// ACT
-			err = subAuth.Authorize(ctx, nilObj, permission.ActionDelete)
+			err = permission.NewAppserverSubAuthorizer(db).Authorize(ctx, nilObj, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)

--- a/src/permission/appserver_test.go
+++ b/src/permission/appserver_test.go
@@ -21,13 +21,13 @@ func TestAppserverAuthorizer_Authorize(t *testing.T) {
 
 	var (
 		err        error
-		authorizer = permission.NewAppserverAuthorizer(testutil.TestDbConn, db.NewQuerier(qx.New(testutil.TestDbConn)))
-		ctx        = testutil.Setup(t, func() {})
+		authorizer = permission.NewAppserverAuthorizer(db.NewQuerier(testutil.TestDbConn))
+		ctx, _     = testutil.Setup(t, func() {})
 	)
 
 	t.Run("ActionRead", func(t *testing.T) {
 		t.Run(string(permission.ActionRead), func(t *testing.T) {
-			t.Run("Successunsubscribe_user_has_access", func(t *testing.T) {
+			t.Run("Success:unsubscribe_user_has_access", func(t *testing.T) {
 				// ACT
 				err = authorizer.Authorize(ctx, nil, permission.ActionRead)
 
@@ -40,7 +40,7 @@ func TestAppserverAuthorizer_Authorize(t *testing.T) {
 	t.Run("ActionCreate", func(t *testing.T) {
 		t.Run(permission.SubActionCreate, func(t *testing.T) {
 
-			t.Run("Successany_user_can_create_appserver", func(t *testing.T) {
+			t.Run("Success:any_user_can_create_appserver", func(t *testing.T) {
 				// ACT
 				err = authorizer.Authorize(ctx, nil, permission.ActionCreate)
 
@@ -53,7 +53,7 @@ func TestAppserverAuthorizer_Authorize(t *testing.T) {
 	t.Run("ActionDelete", func(t *testing.T) {
 		t.Run(permission.SubActionDelete, func(t *testing.T) {
 
-			t.Run("Successowner_can_delete_server", func(t *testing.T) {
+			t.Run("Success:owner_can_delete_server", func(t *testing.T) {
 				// ARRANGE
 				userID, _ := uuid.Parse(ctx.Value(testutil.CtxUserKey).(string))
 				testutil.TestAppuser(t, &qx.Appuser{ID: userID, Username: "foo"}, false)
@@ -69,7 +69,8 @@ func TestAppserverAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:user_with_manage_appserver_permission_cannot_delete_server", func(t *testing.T) {
 				// ARRANGE
-				tu := factory.UserAppserverWithAllPermissions(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
 				idStr := tu.Server.ID.String()
 
 				// ACT
@@ -83,7 +84,8 @@ func TestAppserverAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:user_without_manage_appserver_permission_cannot_delete_server", func(t *testing.T) {
 				// ARRANGE
-				tu := factory.UserAppserverSub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverSub(t, ctx, db)
 				idStr := tu.Server.ID.String()
 
 				// ACT

--- a/src/permission/appserver_test.go
+++ b/src/permission/appserver_test.go
@@ -8,8 +8,6 @@ import (
 	"mist/src/faults"
 	"mist/src/middleware"
 	"mist/src/permission"
-	"mist/src/psql_db/db"
-	"mist/src/psql_db/qx"
 	"mist/src/testutil"
 	"mist/src/testutil/factory"
 
@@ -20,16 +18,17 @@ import (
 func TestAppserverAuthorizer_Authorize(t *testing.T) {
 
 	var (
-		err        error
-		authorizer = permission.NewAppserverAuthorizer(db.NewQuerier(testutil.TestDbConn))
-		ctx, _     = testutil.Setup(t, func() {})
+		err error
 	)
 
 	t.Run("ActionRead", func(t *testing.T) {
 		t.Run(string(permission.ActionRead), func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+
 			t.Run("Success:unsubscribe_user_has_access", func(t *testing.T) {
 				// ACT
-				err = authorizer.Authorize(ctx, nil, permission.ActionRead)
+				err = permission.NewAppserverAuthorizer(db).Authorize(ctx, nil, permission.ActionRead)
 
 				// ASSERT
 				assert.Nil(t, err)
@@ -38,84 +37,84 @@ func TestAppserverAuthorizer_Authorize(t *testing.T) {
 	})
 
 	t.Run("ActionCreate", func(t *testing.T) {
-		t.Run(permission.SubActionCreate, func(t *testing.T) {
 
-			t.Run("Success:any_user_can_create_appserver", func(t *testing.T) {
-				// ACT
-				err = authorizer.Authorize(ctx, nil, permission.ActionCreate)
+		t.Run("Success:any_user_can_create_appserver", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
 
-				// ASSERT
-				assert.Nil(t, err)
-			})
+			// ACT
+			err = permission.NewAppserverAuthorizer(db).Authorize(ctx, nil, permission.ActionCreate)
+
+			// ASSERT
+			assert.Nil(t, err)
 		})
 	})
 
 	t.Run("ActionDelete", func(t *testing.T) {
-		t.Run(permission.SubActionDelete, func(t *testing.T) {
 
-			t.Run("Success:owner_can_delete_server", func(t *testing.T) {
-				// ARRANGE
-				userID, _ := uuid.Parse(ctx.Value(testutil.CtxUserKey).(string))
-				testutil.TestAppuser(t, &qx.Appuser{ID: userID, Username: "foo"}, false)
-				appserver := testutil.TestAppserver(t, &qx.Appserver{Name: "bar", AppuserID: userID}, false)
-				idStr := appserver.ID.String()
+		t.Run("Success:owner_can_delete_server", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			su := factory.UserAppserverOwner(t, ctx, db)
+			idStr := su.Server.ID.String()
 
-				// ACT
-				err = authorizer.Authorize(ctx, &idStr, permission.ActionDelete)
+			// ACT
+			err = permission.NewAppserverAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				// ASSERT
-				assert.Nil(t, err)
-			})
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-			t.Run("Error:user_with_manage_appserver_permission_cannot_delete_server", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
-				idStr := tu.Server.ID.String()
+		t.Run("Error:user_with_manage_appserver_permission_cannot_delete_server", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
+			idStr := tu.Server.ID.String()
 
-				// ACT
-				err = authorizer.Authorize(ctx, &idStr, permission.ActionDelete)
+			// ACT
+			err = permission.NewAppserverAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "user is not allowed to manage server")
-			})
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "user is not allowed to manage server")
+		})
 
-			t.Run("Error:user_without_manage_appserver_permission_cannot_delete_server", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t, ctx, db)
-				idStr := tu.Server.ID.String()
+		t.Run("Error:user_without_manage_appserver_permission_cannot_delete_server", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
+			idStr := tu.Server.ID.String()
 
-				// ACT
-				err = authorizer.Authorize(ctx, &idStr, permission.ActionDelete)
+			// ACT
+			err = permission.NewAppserverAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "user is not allowed to manage server")
-			})
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "user is not allowed to manage server")
+		})
 
-			t.Run("Error:non_owner_cannot_delete_server", func(t *testing.T) {
-				// ARRANGE
-				appserver := testutil.TestAppserver(t, nil, false)
-				idStr := appserver.ID.String()
+		t.Run("Error:non_owner_cannot_delete_server", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			su := factory.UserAppserverSub(t, ctx, db)
+			idStr := su.Server.ID.String()
 
-				// ACT
-				err = authorizer.Authorize(ctx, &idStr, permission.ActionDelete)
+			// ACT
+			err = permission.NewAppserverAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "user is not allowed to manage server")
-			})
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "user is not allowed to manage server")
 		})
 	})
 
 	t.Run("Errors", func(t *testing.T) {
 		t.Run("Error:invalid_user_id_in_context", func(t *testing.T) {
 			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
 			_, claims := testutil.CreateJwtToken(
 				t,
 				&testutil.CreateTokenParams{
@@ -128,7 +127,7 @@ func TestAppserverAuthorizer_Authorize(t *testing.T) {
 			badCtx := context.WithValue(ctx, middleware.JwtClaimsK, claims)
 
 			// ACT
-			err = authorizer.Authorize(badCtx, nil, permission.ActionDelete)
+			err = permission.NewAppserverAuthorizer(db).Authorize(badCtx, nil, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -138,10 +137,11 @@ func TestAppserverAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_object_id_format", func(t *testing.T) {
 			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
 			badId := "invalid"
 
 			// ACT
-			err = authorizer.Authorize(ctx, &badId, permission.ActionDelete)
+			err = permission.NewAppserverAuthorizer(db).Authorize(ctx, &badId, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -151,10 +151,11 @@ func TestAppserverAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:object_id_not_found", func(t *testing.T) {
 			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
 			nonExistentId := uuid.NewString()
 
 			// ACT
-			err = authorizer.Authorize(ctx, &nonExistentId, permission.ActionDelete)
+			err = permission.NewAppserverAuthorizer(db).Authorize(ctx, &nonExistentId, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -162,10 +163,11 @@ func TestAppserverAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:nil_object_errors", func(t *testing.T) {
 			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
 			var nilObj *string
 
 			// ACT
-			err = authorizer.Authorize(ctx, nilObj, permission.ActionDelete)
+			err = permission.NewAppserverAuthorizer(db).Authorize(ctx, nilObj, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)

--- a/src/permission/authorizer.go
+++ b/src/permission/authorizer.go
@@ -14,23 +14,7 @@ const (
 )
 
 const (
-	UndefinedPermission string = "undefined permission"
-	PermissionCtxKey    string = "permission-context"
-)
-
-const (
-	SubActionGetById                      = "get-by-id"
-	SubActionList                         = "list"
-	SubActionListServerRoles              = "list-server-roles"
-	SubActionListChannelRoles             = "list-channel-roles"
-	SubActionListUserServerSubs           = "list-user-server-subs"
-	SubActionListAppserverChannels        = "list-appserver-channels"
-	SubActionListAppserverUserSubs        = "list-appserver-user-subs"
-	SubActionListAppserverUserRoleSubs    = "list-appserver-user-role-subs"
-	SubActionListAppserverUserPermsission = "list-appserver-user-permissions"
-	SubActionCreate                       = "create"
-	SubActionUpdate                       = "update"
-	SubActionDelete                       = "delete"
+	PermissionCtxKey string = "permission-context"
 )
 
 type Authorizer interface {

--- a/src/permission/channel.go
+++ b/src/permission/channel.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5"
 
 	"mist/src/faults"
 	"mist/src/middleware"
@@ -16,18 +16,16 @@ import (
 )
 
 type ChannelAuthorizer struct {
-	DbConn *pgxpool.Pool
+	DbTx   pgx.Tx
 	Db     db.Querier
 	shared *SharedAuthorizer
 }
 
-func NewChannelAuthorizer(DbConn *pgxpool.Pool, Db db.Querier) *ChannelAuthorizer {
+func NewChannelAuthorizer(Db db.Querier) *ChannelAuthorizer {
 	return &ChannelAuthorizer{
-		DbConn: DbConn,
-		Db:     Db,
+		Db: Db,
 		shared: &SharedAuthorizer{
-			DbConn: DbConn,
-			Db:     Db,
+			Db: Db,
 		},
 	}
 }
@@ -73,7 +71,7 @@ func (auth *ChannelAuthorizer) Authorize(
 	}
 
 	if objId != nil {
-		_, err = GetObject(ctx, auth.shared, objId, service.NewChannelService(ctx, &service.ServiceDeps{Db: auth.Db, DbConn: auth.DbConn}).GetById)
+		_, err = GetObject(ctx, auth.shared, objId, service.NewChannelService(ctx, &service.ServiceDeps{Db: auth.Db}).GetById)
 
 		if err != nil {
 			// if the object is not found or invalid uuid, we return error
@@ -81,7 +79,7 @@ func (auth *ChannelAuthorizer) Authorize(
 		}
 	}
 
-	server, err = service.NewAppserverService(ctx, &service.ServiceDeps{Db: auth.Db, DbConn: auth.DbConn}).GetById(serverIdCtx.AppserverId)
+	server, err = service.NewAppserverService(ctx, &service.ServiceDeps{Db: auth.Db}).GetById(serverIdCtx.AppserverId)
 
 	if err != nil {
 		// if the object is not found or invalid uuid, we return error

--- a/src/permission/channel.go
+++ b/src/permission/channel.go
@@ -52,7 +52,6 @@ func (auth *ChannelAuthorizer) Authorize(
 	if userId, err = uuid.Parse(claims.UserID); err != nil {
 		return faults.AuthorizationError(fmt.Sprintf("invalid user id: %s", claims.UserID), slog.LevelDebug)
 	}
-
 	serverIdCtx, authOk = ctx.Value(PermissionCtxKey).(*AppserverIdAuthCtx)
 
 	if !authOk {

--- a/src/permission/channel_role_test.go
+++ b/src/permission/channel_role_test.go
@@ -13,7 +13,6 @@ import (
 	"mist/src/faults"
 	"mist/src/middleware"
 	"mist/src/permission"
-	"mist/src/psql_db/db"
 	"mist/src/psql_db/qx"
 	"mist/src/testutil"
 	"mist/src/testutil/factory"
@@ -21,8 +20,7 @@ import (
 
 func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 	var (
-		err             error
-		channelRoleAuth = permission.NewChannelRoleAuthorizer(db.NewQuerier(testutil.TestDbConn))
+		err error
 	)
 
 	t.Run("ActionRead", func(t *testing.T) {
@@ -36,7 +34,7 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 			})
 
 			// ACT
-			err = channelRoleAuth.Authorize(ctx, nil, permission.ActionRead)
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionRead)
 
 			// ASSERT
 			assert.Nil(t, err)
@@ -52,7 +50,7 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 			})
 
 			// ACT
-			err = channelRoleAuth.Authorize(ctx, nil, permission.ActionRead)
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionRead)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -62,184 +60,158 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 	})
 
 	t.Run("ActionWrite", func(t *testing.T) {
-		t.Run(permission.SubActionCreate, func(t *testing.T) {
 
-			t.Run("Success:owner_can_create_channel_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t, ctx, db)
+		t.Run("Success:owner_can_create_channel_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverOwner(t, ctx, db)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-
-				// ACT
-				err = channelRoleAuth.Authorize(ctx, nil, permission.ActionCreate)
-
-				// ASSERT
-				assert.Nil(t, err)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Success:user_with_appserver_permission_can_create_channel_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
+			// ACT
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionCreate)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ACT
-				err = channelRoleAuth.Authorize(ctx, nil, permission.ActionWrite)
+		t.Run("Success:user_with_appserver_permission_can_create_channel_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
 
-				// ASSERT
-				assert.Nil(t, err)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Error:subscribed_user_cannot_create_channel_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t, ctx, db)
+			// ACT
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionWrite)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ACT
-				err = channelRoleAuth.Authorize(ctx, nil, permission.ActionWrite)
+		t.Run("Error:subscribed_user_cannot_create_channel_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channel roles")
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Error:unsubscribed_user_cannot_create_channel_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t, ctx, db)
+			// ACT
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionWrite)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channel roles")
+		})
 
-				// ACT
-				err = channelRoleAuth.Authorize(ctx, nil, permission.ActionWrite)
+		t.Run("Error:unsubscribed_user_cannot_create_channel_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverUnsub(t, ctx, db)
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channel roles")
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+
+			// ACT
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionWrite)
+
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channel roles")
 		})
 	})
 
 	t.Run("ActionDelete", func(t *testing.T) {
-		t.Run(permission.SubActionDelete, func(t *testing.T) {
 
-			t.Run("Success:owner_can_delete_channel_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t, ctx, db)
-				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
-				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "admin", AppserverID: tu.Server.ID}, false)
-				channelRole := testutil.TestChannelRole(t, &qx.ChannelRole{
-					AppserverID:     tu.Server.ID,
-					AppserverRoleID: role.ID,
-					ChannelID:       channel.ID,
-				}, false)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				idStr := channelRole.ID.String()
-
-				// ACT
-				err = channelRoleAuth.Authorize(ctx, &idStr, permission.ActionDelete)
-
-				// ASSERT
-				assert.Nil(t, err)
+		t.Run("Success:owner_can_delete_channel_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverOwner(t, ctx, db)
+			channelRole := factory.NewFactory(ctx, db).ChannelRole(t, 0, nil)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			idStr := channelRole.ID.String()
 
-			t.Run("Success:user_with_permission_role_can_delete_channel_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
-				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
-				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "anothaone", AppserverID: tu.Server.ID}, false)
-				channelRole := testutil.TestChannelRole(t, &qx.ChannelRole{
-					AppserverID:     tu.Server.ID,
-					AppserverRoleID: role.ID,
-					ChannelID:       channel.ID,
-				}, false)
+			// ACT
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				idStr := channelRole.ID.String()
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ACT
-				err = channelRoleAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+		t.Run("Success:user_with_permission_role_can_delete_channel_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
+			channelRole := factory.NewFactory(ctx, db).ChannelRole(t, 0, nil)
 
-				// ASSERT
-				assert.Nil(t, err)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			idStr := channelRole.ID.String()
 
-			t.Run("Error:subscribed_user_without_permission_cannot_delete_channel_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t, ctx, db)
-				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
-				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "admin", AppserverID: tu.Server.ID}, false)
-				channelRole := testutil.TestChannelRole(t, &qx.ChannelRole{
-					AppserverID:     tu.Server.ID,
-					AppserverRoleID: role.ID,
-					ChannelID:       channel.ID,
-				}, false)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				idStr := channelRole.ID.String()
+			// ACT
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				// ACT
-				err = channelRoleAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channel roles")
+		t.Run("Error:subscribed_user_without_permission_cannot_delete_channel_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
+			channelRole := factory.NewFactory(ctx, db).ChannelRole(t, 0, nil)
+
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			idStr := channelRole.ID.String()
 
-			t.Run("Error:unsubscribed_user_cannot_delete_channel_role", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t, ctx, db)
-				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
-				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "admin", AppserverID: tu.Server.ID}, false)
-				channelRole := testutil.TestChannelRole(t, &qx.ChannelRole{
-					AppserverID:     tu.Server.ID,
-					AppserverRoleID: role.ID,
-					ChannelID:       channel.ID,
-				}, false)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				idStr := channelRole.ID.String()
+			// ACT
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				// ACT
-				err = channelRoleAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channel roles")
+		})
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channel roles")
+		t.Run("Error:unsubscribed_user_cannot_delete_channel_role", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverUnsub(t, ctx, db)
+			channelRole := factory.NewFactory(ctx, db).ChannelRole(t, 0, nil)
+
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			idStr := channelRole.ID.String()
+
+			// ACT
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
+
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channel roles")
 		})
 	})
 
 	t.Run("Errors", func(t *testing.T) {
 		t.Run("Error:invalid_userid_in_context", func(t *testing.T) {
 			// ARRANGE
-			ctx, _ := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			_, claims := testutil.CreateJwtToken(t, &testutil.CreateTokenParams{
 				Iss:       os.Getenv("MIST_API_JWT_ISSUER"),
 				Aud:       []string{os.Getenv("MIST_API_JWT_AUDIENCE")},
@@ -249,7 +221,7 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 			badCtx := context.WithValue(ctx, middleware.JwtClaimsK, claims)
 
 			// ACT
-			err = channelRoleAuth.Authorize(badCtx, nil, permission.ActionRead)
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(badCtx, nil, permission.ActionRead)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -259,15 +231,15 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_sub_check", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
+			idStr := uuid.New().String()
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: uuid.New(),
+			})
+
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
 			mockChannelRoleAuth := permission.NewChannelRoleAuthorizer(mockQuerier)
-			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
-			})
-			idStr := uuid.New().String()
 
 			// ACT
 			err = mockChannelRoleAuth.Authorize(ctx, &idStr, permission.ActionDelete)
@@ -280,26 +252,29 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_server_search", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
+			serverId := uuid.New()
+			userId := uuid.New()
+			subId := uuid.New()
+			idStr := uuid.New().String()
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: serverId,
+			})
+
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
-					ID:          tu.Sub.ID,
-					AppserverID: tu.Server.ID,
-					AppuserID:   tu.User.ID,
+					ID:          subId,
+					AppserverID: serverId,
+					AppuserID:   userId,
 				},
 			}, nil)
 			mockQuerier.On("GetChannelRoleById", mock.Anything, mock.Anything).Return(qx.ChannelRole{
-				ID:          tu.Sub.ID,
-				AppserverID: tu.Server.ID,
+				ID:          subId,
+				AppserverID: serverId,
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
 			mockChannelRoleAuth := permission.NewChannelRoleAuthorizer(mockQuerier)
-			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
-			})
-			idStr := uuid.New().String()
 
 			// ACT
 			err = mockChannelRoleAuth.Authorize(ctx, &idStr, permission.ActionDelete)
@@ -313,28 +288,31 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_user_permission_mask", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
+			serverId := uuid.New()
+			userId := uuid.New()
+			subId := uuid.New()
+
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
-					ID:          tu.Sub.ID,
-					AppserverID: tu.Server.ID,
-					AppuserID:   tu.User.ID,
+					ID:          subId,
+					AppserverID: serverId,
+					AppuserID:   userId,
 				},
 			}, nil)
 			mockQuerier.On("GetChannelRoleById", mock.Anything, mock.Anything).Return(qx.ChannelRole{
-				ID:          tu.Sub.ID,
-				AppserverID: tu.Server.ID,
+				ID:          subId,
+				AppserverID: serverId,
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(qx.Appserver{
-				ID:        tu.Server.ID,
-				AppuserID: tu.Server.AppuserID,
+				ID:        serverId,
+				AppuserID: userId,
 			}, nil)
 			mockQuerier.On("GetAppuserRoles", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
 			mockChannelRoleAuth := permission.NewChannelRoleAuthorizer(mockQuerier)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
+				AppserverId: serverId,
 			})
 			idStr := uuid.New().String()
 
@@ -352,14 +330,14 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 			// ARRANGE
 			ctx, db := testutil.Setup(t, func() {})
 			tu := factory.UserAppserverSub(t, ctx, db)
-			testutil.TestAppserverSub(t, nil, true)
+
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
 			badId := "invalid"
 
 			// ACT
-			err = channelRoleAuth.Authorize(ctx, &badId, permission.ActionDelete)
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, &badId, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -369,12 +347,12 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_server_id_format", func(t *testing.T) {
 			// ARRANGE
-			ctx, _ := testutil.Setup(t, func() {})
-			testutil.TestAppserverSub(t, nil, true)
+			ctx, db := testutil.Setup(t, func() {})
+			factory.UserAppserverSub(t, ctx, db)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, "invalid")
 
 			// ACT
-			err = channelRoleAuth.Authorize(ctx, nil, permission.ActionDelete)
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, nil, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -386,14 +364,13 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 			// ARRANGE
 			ctx, db := testutil.Setup(t, func() {})
 			tu := factory.UserAppserverSub(t, ctx, db)
-			testutil.TestAppserverSub(t, nil, true)
 			nonExistentId := uuid.NewString()
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
 
 			// ACT
-			err = channelRoleAuth.Authorize(ctx, &nonExistentId, permission.ActionDelete)
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, &nonExistentId, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -411,7 +388,7 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 			var nilObj *string
 
 			// ACT
-			err = channelRoleAuth.Authorize(ctx, nilObj, permission.ActionDelete)
+			err = permission.NewChannelRoleAuthorizer(db).Authorize(ctx, nilObj, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)

--- a/src/permission/channel_role_test.go
+++ b/src/permission/channel_role_test.go
@@ -22,14 +22,14 @@ import (
 func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 	var (
 		err             error
-		channelRoleAuth = permission.NewChannelRoleAuthorizer(testutil.TestDbConn, db.NewQuerier(qx.New(testutil.TestDbConn)))
+		channelRoleAuth = permission.NewChannelRoleAuthorizer(db.NewQuerier(testutil.TestDbConn))
 	)
 
 	t.Run("ActionRead", func(t *testing.T) {
-		t.Run("Successsubscribed_user_can_read_channels", func(t *testing.T) {
+		t.Run("Success:subscribed_user_can_read_channels", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
@@ -44,8 +44,8 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:unsubscribed_user_cannot_read", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			sub := factory.UserAppserverUnsub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			sub := factory.UserAppserverUnsub(t, ctx, db)
 
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: sub.Server.ID,
@@ -64,10 +64,10 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 	t.Run("ActionWrite", func(t *testing.T) {
 		t.Run(permission.SubActionCreate, func(t *testing.T) {
 
-			t.Run("Successowner_can_create_channel_role", func(t *testing.T) {
+			t.Run("Success:owner_can_create_channel_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverOwner(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -80,10 +80,10 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 				assert.Nil(t, err)
 			})
 
-			t.Run("Successuser_with_appserver_permission_can_create_channel_role", func(t *testing.T) {
+			t.Run("Success:user_with_appserver_permission_can_create_channel_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -98,8 +98,8 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:subscribed_user_cannot_create_channel_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverSub(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -116,8 +116,8 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:unsubscribed_user_cannot_create_channel_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverUnsub(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -137,10 +137,10 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 	t.Run("ActionDelete", func(t *testing.T) {
 		t.Run(permission.SubActionDelete, func(t *testing.T) {
 
-			t.Run("Successowner_can_delete_channel_role", func(t *testing.T) {
+			t.Run("Success:owner_can_delete_channel_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverOwner(t, ctx, db)
 				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
 				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "admin", AppserverID: tu.Server.ID}, false)
 				channelRole := testutil.TestChannelRole(t, &qx.ChannelRole{
@@ -160,10 +160,10 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 				assert.Nil(t, err)
 			})
 
-			t.Run("Successuser_with_permission_role_can_delete_channel_role", func(t *testing.T) {
+			t.Run("Success:user_with_permission_role_can_delete_channel_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
 				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
 				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "anothaone", AppserverID: tu.Server.ID}, false)
 				channelRole := testutil.TestChannelRole(t, &qx.ChannelRole{
@@ -186,8 +186,8 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:subscribed_user_without_permission_cannot_delete_channel_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverSub(t, ctx, db)
 				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
 				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "admin", AppserverID: tu.Server.ID}, false)
 				channelRole := testutil.TestChannelRole(t, &qx.ChannelRole{
@@ -211,8 +211,8 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:unsubscribed_user_cannot_delete_channel_role", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverUnsub(t, ctx, db)
 				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
 				role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "admin", AppserverID: tu.Server.ID}, false)
 				channelRole := testutil.TestChannelRole(t, &qx.ChannelRole{
@@ -239,7 +239,7 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 	t.Run("Errors", func(t *testing.T) {
 		t.Run("Error:invalid_userid_in_context", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
 			_, claims := testutil.CreateJwtToken(t, &testutil.CreateTokenParams{
 				Iss:       os.Getenv("MIST_API_JWT_ISSUER"),
 				Aud:       []string{os.Getenv("MIST_API_JWT_AUDIENCE")},
@@ -259,11 +259,11 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_sub_check", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t)
+			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockChannelRoleAuth := permission.NewChannelRoleAuthorizer(testutil.TestDbConn, mockQuerier)
+			mockChannelRoleAuth := permission.NewChannelRoleAuthorizer(mockQuerier)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
@@ -280,9 +280,9 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_server_search", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t)
+			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
 					ID:          tu.Sub.ID,
@@ -295,7 +295,7 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 				AppserverID: tu.Server.ID,
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockChannelRoleAuth := permission.NewChannelRoleAuthorizer(testutil.TestDbConn, mockQuerier)
+			mockChannelRoleAuth := permission.NewChannelRoleAuthorizer(mockQuerier)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
@@ -313,9 +313,9 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_user_permission_mask", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t)
+			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
 					ID:          tu.Sub.ID,
@@ -332,7 +332,7 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 				AppuserID: tu.Server.AppuserID,
 			}, nil)
 			mockQuerier.On("GetAppuserRoles", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockChannelRoleAuth := permission.NewChannelRoleAuthorizer(testutil.TestDbConn, mockQuerier)
+			mockChannelRoleAuth := permission.NewChannelRoleAuthorizer(mockQuerier)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
@@ -350,8 +350,8 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_object_id_format", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 			testutil.TestAppserverSub(t, nil, true)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
@@ -369,7 +369,7 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_server_id_format", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
 			testutil.TestAppserverSub(t, nil, true)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, "invalid")
 
@@ -384,8 +384,8 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:object_id_not_found", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 			testutil.TestAppserverSub(t, nil, true)
 			nonExistentId := uuid.NewString()
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
@@ -402,8 +402,8 @@ func TestChannelRoleAuthorizer_Authorize(t *testing.T) {
 		})
 
 		t.Run("Error:nil_object_errors", func(t *testing.T) {
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})

--- a/src/permission/channel_test.go
+++ b/src/permission/channel_test.go
@@ -22,14 +22,14 @@ import (
 func TestChannelAuthorizer_Authorize(t *testing.T) {
 	var (
 		err         error
-		channelAuth = permission.NewChannelAuthorizer(testutil.TestDbConn, db.NewQuerier(qx.New(testutil.TestDbConn)))
+		channelAuth = permission.NewChannelAuthorizer(db.NewQuerier(testutil.TestDbConn))
 	)
 
 	t.Run("ActionRead", func(t *testing.T) {
-		t.Run("Successsubscribed_user_can_read_channels", func(t *testing.T) {
+		t.Run("Success:subscribed_user_can_read_channels", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
@@ -44,8 +44,8 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:unsubscribed_user_cannot_read", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			sub := factory.UserAppserverUnsub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			sub := factory.UserAppserverUnsub(t, ctx, db)
 
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: sub.Server.ID,
@@ -64,10 +64,10 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 	t.Run("ActionWrite", func(t *testing.T) {
 		t.Run(permission.SubActionCreate, func(t *testing.T) {
 
-			t.Run("Successowner_can_create_channel", func(t *testing.T) {
+			t.Run("Success:owner_can_create_channel", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverOwner(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -80,10 +80,10 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 				assert.Nil(t, err)
 			})
 
-			t.Run("Successuser_with_appserver_permission_can_create_channel", func(t *testing.T) {
+			t.Run("Success:user_with_appserver_permission_can_create_channel", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -98,8 +98,8 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:subscribed_user_cannot_create_channel", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverSub(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -116,8 +116,8 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:unsubscribed_user_cannot_create_channel", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverUnsub(t, ctx, db)
 
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -137,10 +137,10 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 	t.Run("ActionDelete", func(t *testing.T) {
 		t.Run(permission.SubActionDelete, func(t *testing.T) {
 
-			t.Run("Successowner_can_delete_channel", func(t *testing.T) {
+			t.Run("Success:owner_can_delete_channel", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverOwner(t, ctx, db)
 				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -154,10 +154,10 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 				assert.Nil(t, err)
 			})
 
-			t.Run("Successuser_with_permission_role_can_delete_channel", func(t *testing.T) {
+			t.Run("Success:user_with_permission_role_can_delete_channel", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
 				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -173,8 +173,8 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:subscribed_user_without_permission_cannot_delete_channel", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverSub(t, ctx, db)
 				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -192,8 +192,8 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 			t.Run("Error:unsubscribed_user_cannot_delete_channel", func(t *testing.T) {
 				// ARRANGE
-				ctx := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t)
+				ctx, db := testutil.Setup(t, func() {})
+				tu := factory.UserAppserverUnsub(t, ctx, db)
 				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
 				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 					AppserverId: tu.Server.ID,
@@ -214,7 +214,7 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 	t.Run("Errors", func(t *testing.T) {
 		t.Run("Error:invalid_userid_in_context", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
 			_, claims := testutil.CreateJwtToken(t, &testutil.CreateTokenParams{
 				Iss:       os.Getenv("MIST_API_JWT_ISSUER"),
 				Aud:       []string{os.Getenv("MIST_API_JWT_AUDIENCE")},
@@ -234,11 +234,11 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_sub_check", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t)
+			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockChannelAuth := permission.NewChannelAuthorizer(testutil.TestDbConn, mockQuerier)
+			mockChannelAuth := permission.NewChannelAuthorizer(mockQuerier)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
@@ -255,9 +255,9 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_server_search", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t)
+			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
 					ID:          tu.Sub.ID,
@@ -271,7 +271,7 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 				Name:        "boo",
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockChannelAuth := permission.NewChannelAuthorizer(testutil.TestDbConn, mockQuerier)
+			mockChannelAuth := permission.NewChannelAuthorizer(mockQuerier)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
@@ -289,9 +289,9 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_user_permission_mask", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t)
+			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
 					ID:          tu.Sub.ID,
@@ -309,7 +309,7 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 				AppuserID: tu.Server.AppuserID,
 			}, nil)
 			mockQuerier.On("GetAppuserRoles", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
-			mockChannelAuth := permission.NewChannelAuthorizer(testutil.TestDbConn, mockQuerier)
+			mockChannelAuth := permission.NewChannelAuthorizer(mockQuerier)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
@@ -327,8 +327,8 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_object_id_format", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 			testutil.TestAppserverSub(t, nil, true)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
@@ -346,7 +346,7 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_server_id_format", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
 			testutil.TestAppserverSub(t, nil, true)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, "invalid")
 
@@ -361,8 +361,8 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:object_id_not_found", func(t *testing.T) {
 			// ARRANGE
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 			testutil.TestAppserverSub(t, nil, true)
 			nonExistentId := uuid.NewString()
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
@@ -379,8 +379,8 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 		})
 
 		t.Run("Error:nil_object_errors", func(t *testing.T) {
-			ctx := testutil.Setup(t, func() {})
-			tu := factory.UserAppserverSub(t)
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})

--- a/src/permission/channel_test.go
+++ b/src/permission/channel_test.go
@@ -13,7 +13,6 @@ import (
 	"mist/src/faults"
 	"mist/src/middleware"
 	"mist/src/permission"
-	"mist/src/psql_db/db"
 	"mist/src/psql_db/qx"
 	"mist/src/testutil"
 	"mist/src/testutil/factory"
@@ -21,8 +20,7 @@ import (
 
 func TestChannelAuthorizer_Authorize(t *testing.T) {
 	var (
-		err         error
-		channelAuth = permission.NewChannelAuthorizer(db.NewQuerier(testutil.TestDbConn))
+		err error
 	)
 
 	t.Run("ActionRead", func(t *testing.T) {
@@ -36,7 +34,7 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 			})
 
 			// ACT
-			err = channelAuth.Authorize(ctx, nil, permission.ActionRead)
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, nil, permission.ActionRead)
 
 			// ASSERT
 			assert.Nil(t, err)
@@ -52,7 +50,7 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 			})
 
 			// ACT
-			err = channelAuth.Authorize(ctx, nil, permission.ActionRead)
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, nil, permission.ActionRead)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -62,159 +60,155 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 	})
 
 	t.Run("ActionWrite", func(t *testing.T) {
-		t.Run(permission.SubActionCreate, func(t *testing.T) {
 
-			t.Run("Success:owner_can_create_channel", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t, ctx, db)
+		t.Run("Success:owner_can_create_channel", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverOwner(t, ctx, db)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-
-				// ACT
-				err = channelAuth.Authorize(ctx, nil, permission.ActionCreate)
-
-				// ASSERT
-				assert.Nil(t, err)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Success:user_with_appserver_permission_can_create_channel", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
+			// ACT
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, nil, permission.ActionCreate)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ACT
-				err = channelAuth.Authorize(ctx, nil, permission.ActionWrite)
+		t.Run("Success:user_with_appserver_permission_can_create_channel", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
 
-				// ASSERT
-				assert.Nil(t, err)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Error:subscribed_user_cannot_create_channel", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t, ctx, db)
+			// ACT
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, nil, permission.ActionWrite)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ACT
-				err = channelAuth.Authorize(ctx, nil, permission.ActionWrite)
+		t.Run("Error:subscribed_user_cannot_create_channel", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channels")
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Error:unsubscribed_user_cannot_create_channel", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t, ctx, db)
+			// ACT
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, nil, permission.ActionWrite)
 
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channels")
+		})
 
-				// ACT
-				err = channelAuth.Authorize(ctx, nil, permission.ActionWrite)
+		t.Run("Error:unsubscribed_user_cannot_create_channel", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverUnsub(t, ctx, db)
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channels")
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+
+			// ACT
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, nil, permission.ActionWrite)
+
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channels")
 		})
 	})
 
 	t.Run("ActionDelete", func(t *testing.T) {
-		t.Run(permission.SubActionDelete, func(t *testing.T) {
 
-			t.Run("Success:owner_can_delete_channel", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverOwner(t, ctx, db)
-				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				idStr := channel.ID.String()
-
-				// ACT
-				err = channelAuth.Authorize(ctx, &idStr, permission.ActionDelete)
-
-				// ASSERT
-				assert.Nil(t, err)
+		t.Run("Success:owner_can_delete_channel", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverOwner(t, ctx, db)
+			channel := factory.NewFactory(ctx, db).Channel(t, 0, nil)
+			idStr := channel.ID.String()
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
 
-			t.Run("Success:user_with_permission_role_can_delete_channel", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
-				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				idStr := channel.ID.String()
+			// ACT
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				// ACT
-				err = channelAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ASSERT
-				assert.Nil(t, err)
+		t.Run("Success:user_with_permission_role_can_delete_channel", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverWithAllPermissions(t, ctx, db)
+			channel := factory.NewFactory(ctx, db).Channel(t, 0, nil)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			idStr := channel.ID.String()
 
-			t.Run("Error:subscribed_user_without_permission_cannot_delete_channel", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverSub(t, ctx, db)
-				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				idStr := channel.ID.String()
+			// ACT
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				// ACT
-				err = channelAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			// ASSERT
+			assert.Nil(t, err)
+		})
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channels")
+		t.Run("Error:subscribed_user_without_permission_cannot_delete_channel", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverSub(t, ctx, db)
+			channel := factory.NewFactory(ctx, db).Channel(t, 0, nil)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			idStr := channel.ID.String()
 
-			t.Run("Error:unsubscribed_user_cannot_delete_channel", func(t *testing.T) {
-				// ARRANGE
-				ctx, db := testutil.Setup(t, func() {})
-				tu := factory.UserAppserverUnsub(t, ctx, db)
-				channel := testutil.TestChannel(t, &qx.Channel{Name: "foo", AppserverID: tu.Server.ID}, false)
-				ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-					AppserverId: tu.Server.ID,
-				})
-				idStr := channel.ID.String()
+			// ACT
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
 
-				// ACT
-				err = channelAuth.Authorize(ctx, &idStr, permission.ActionDelete)
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channels")
+		})
 
-				// ASSERT
-				assert.NotNil(t, err)
-				assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
-				testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channels")
+		t.Run("Error:unsubscribed_user_cannot_delete_channel", func(t *testing.T) {
+			// ARRANGE
+			ctx, db := testutil.Setup(t, func() {})
+			tu := factory.UserAppserverUnsub(t, ctx, db)
+			channel := factory.NewFactory(ctx, db).Channel(t, 0, nil)
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: tu.Server.ID,
 			})
+			idStr := channel.ID.String()
+
+			// ACT
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, &idStr, permission.ActionDelete)
+
+			// ASSERT
+			assert.NotNil(t, err)
+			assert.Equal(t, err.Error(), faults.AuthorizationErrorMessage)
+			testutil.AssertCustomErrorContains(t, err, "user does not have permission to manage channels")
 		})
 	})
 
 	t.Run("Errors", func(t *testing.T) {
 		t.Run("Error:invalid_userid_in_context", func(t *testing.T) {
 			// ARRANGE
-			ctx, _ := testutil.Setup(t, func() {})
+			ctx, db := testutil.Setup(t, func() {})
 			_, claims := testutil.CreateJwtToken(t, &testutil.CreateTokenParams{
 				Iss:       os.Getenv("MIST_API_JWT_ISSUER"),
 				Aud:       []string{os.Getenv("MIST_API_JWT_AUDIENCE")},
@@ -224,7 +218,7 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 			badCtx := context.WithValue(ctx, middleware.JwtClaimsK, claims)
 
 			// ACT
-			err = channelAuth.Authorize(badCtx, nil, permission.ActionRead)
+			err = permission.NewChannelAuthorizer(db).Authorize(badCtx, nil, permission.ActionRead)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -234,13 +228,14 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_sub_check", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
+
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
+
 			mockChannelAuth := permission.NewChannelAuthorizer(mockQuerier)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
+				AppserverId: uuid.New(),
 			})
 			idStr := uuid.New().String()
 
@@ -255,27 +250,31 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_server_search", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
+			subId := uuid.New()
+			serverId := uuid.New()
+			userId := uuid.New()
+			idStr := uuid.New().String()
+			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
+				AppserverId: serverId,
+			})
+
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
-					ID:          tu.Sub.ID,
-					AppserverID: tu.Server.ID,
-					AppuserID:   tu.User.ID,
+					ID:          subId,
+					AppserverID: serverId,
+					AppuserID:   userId,
 				},
 			}, nil)
 			mockQuerier.On("GetChannelById", mock.Anything, mock.Anything).Return(qx.Channel{
-				ID:          tu.Sub.ID,
-				AppserverID: tu.Server.ID,
+				ID:          subId,
+				AppserverID: serverId,
 				Name:        "boo",
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
+
 			mockChannelAuth := permission.NewChannelAuthorizer(mockQuerier)
-			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
-			})
-			idStr := uuid.New().String()
 
 			// ACT
 			err = mockChannelAuth.Authorize(ctx, &idStr, permission.ActionDelete)
@@ -289,31 +288,34 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:db_error_on_user_permission_mask", func(t *testing.T) {
 			// ARRANGE
-			ctx, db := testutil.Setup(t, func() {})
+			ctx, _ := testutil.Setup(t, func() {})
+			serverId := uuid.New()
+			subId := uuid.New()
+			userId := uuid.New()
+			idStr := uuid.New().String()
+
 			mockQuerier := new(testutil.MockQuerier)
-			tu := factory.UserAppserverSub(t, ctx, db)
 			mockQuerier.On("FilterAppserverSub", mock.Anything, mock.Anything).Return([]qx.FilterAppserverSubRow{
 				{
-					ID:          tu.Sub.ID,
-					AppserverID: tu.Server.ID,
-					AppuserID:   tu.User.ID,
+					ID:          subId,
+					AppserverID: serverId,
+					AppuserID:   userId,
 				},
 			}, nil)
 			mockQuerier.On("GetChannelById", mock.Anything, mock.Anything).Return(qx.Channel{
-				ID:          tu.Sub.ID,
-				AppserverID: tu.Server.ID,
+				ID:          subId,
+				AppserverID: serverId,
 				Name:        "boo",
 			}, nil)
 			mockQuerier.On("GetAppserverById", mock.Anything, mock.Anything).Return(qx.Appserver{
-				ID:        tu.Server.ID,
-				AppuserID: tu.Server.AppuserID,
+				ID:        serverId,
+				AppuserID: userId,
 			}, nil)
 			mockQuerier.On("GetAppuserRoles", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
 			mockChannelAuth := permission.NewChannelAuthorizer(mockQuerier)
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
-				AppserverId: tu.Server.ID,
+				AppserverId: serverId,
 			})
-			idStr := uuid.New().String()
 
 			// ACT
 			err = mockChannelAuth.Authorize(ctx, &idStr, permission.ActionDelete)
@@ -329,14 +331,14 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 			// ARRANGE
 			ctx, db := testutil.Setup(t, func() {})
 			tu := factory.UserAppserverSub(t, ctx, db)
-			testutil.TestAppserverSub(t, nil, true)
+
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
 			badId := "invalid"
 
 			// ACT
-			err = channelAuth.Authorize(ctx, &badId, permission.ActionDelete)
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, &badId, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -346,12 +348,11 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 
 		t.Run("Error:invalid_server_id_format", func(t *testing.T) {
 			// ARRANGE
-			ctx, _ := testutil.Setup(t, func() {})
-			testutil.TestAppserverSub(t, nil, true)
+			ctx, db := testutil.Setup(t, func() {})
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, "invalid")
 
 			// ACT
-			err = channelAuth.Authorize(ctx, nil, permission.ActionDelete)
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, nil, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -363,14 +364,13 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 			// ARRANGE
 			ctx, db := testutil.Setup(t, func() {})
 			tu := factory.UserAppserverSub(t, ctx, db)
-			testutil.TestAppserverSub(t, nil, true)
 			nonExistentId := uuid.NewString()
 			ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{
 				AppserverId: tu.Server.ID,
 			})
 
 			// ACT
-			err = channelAuth.Authorize(ctx, &nonExistentId, permission.ActionDelete)
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, &nonExistentId, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)
@@ -388,7 +388,7 @@ func TestChannelAuthorizer_Authorize(t *testing.T) {
 			var nilObj *string
 
 			// ACT
-			err = channelAuth.Authorize(ctx, nilObj, permission.ActionDelete)
+			err = permission.NewChannelAuthorizer(db).Authorize(ctx, nilObj, permission.ActionDelete)
 
 			// ASSERT
 			assert.NotNil(t, err)

--- a/src/permission/constants.go
+++ b/src/permission/constants.go
@@ -2,12 +2,12 @@ package permission
 
 const (
 	// Appserver Permission
-	ManageChannels = 1 << 1
-	ManageRoles     = 1 << 2
-	ManageAppserver = 1 << 3
+	ManageChannels  = 1
+	ManageRoles     = 1 << 1
+	ManageAppserver = 1 << 2
 
 	// Channel Permissions
 
 	// Sub Permissions
-	ManageSubs = 1 << 1
+	ManageSubs = 1
 )

--- a/src/permission/shared.go
+++ b/src/permission/shared.go
@@ -10,13 +10,11 @@ import (
 	"mist/src/service"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type SharedAuthorizer struct {
-	DbTx pgx.Tx
-	Db   db.Querier
+	Db db.Querier
 }
 
 type AppserverIdAuthCtx struct {

--- a/src/permission/shared.go
+++ b/src/permission/shared.go
@@ -10,13 +10,13 @@ import (
 	"mist/src/service"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type SharedAuthorizer struct {
-	DbConn *pgxpool.Pool
-	Db     db.Querier
+	DbTx pgx.Tx
+	Db   db.Querier
 }
 
 type AppserverIdAuthCtx struct {
@@ -29,16 +29,15 @@ type PermissionMasks struct {
 	SubPermissionMask       int64
 }
 
-func NewSharedAuthorizer(DbConn *pgxpool.Pool, Db db.Querier) *SharedAuthorizer {
+func NewSharedAuthorizer(Db db.Querier) *SharedAuthorizer {
 	return &SharedAuthorizer{
-		DbConn: DbConn,
-		Db:     Db,
+		Db: Db,
 	}
 }
 
 // Helper function to determine whether a user is owner of the server.
 func (auth *SharedAuthorizer) UserIsServerOwner(ctx context.Context, userId uuid.UUID, serverId uuid.UUID) (bool, error) {
-	server, err := service.NewAppserverService(ctx, &service.ServiceDeps{Db: auth.Db, DbConn: auth.DbConn}).GetById(serverId)
+	server, err := service.NewAppserverService(ctx, &service.ServiceDeps{Db: auth.Db}).GetById(serverId)
 
 	if err != nil {
 		return false, faults.ExtendError(err)
@@ -49,7 +48,7 @@ func (auth *SharedAuthorizer) UserIsServerOwner(ctx context.Context, userId uuid
 
 // Helper function to determine whether a user is owner of the server.
 func (auth *SharedAuthorizer) UserHasServerSub(ctx context.Context, userId uuid.UUID, serverId uuid.UUID) (bool, error) {
-	sub, err := service.NewAppserverSubService(ctx, &service.ServiceDeps{Db: auth.Db, DbConn: auth.DbConn}).Filter(
+	sub, err := service.NewAppserverSubService(ctx, &service.ServiceDeps{Db: auth.Db}).Filter(
 		qx.FilterAppserverSubParams{
 			AppserverID: pgtype.UUID{Valid: true, Bytes: serverId},
 			AppuserID:   pgtype.UUID{Valid: true, Bytes: userId},
@@ -112,7 +111,7 @@ func GetUserPermissionMask(
 
 	roles, err := service.NewAppserverRoleService(
 		ctx,
-		&service.ServiceDeps{Db: auth.Db, DbConn: auth.DbConn}).GetAppuserRoles(qx.GetAppuserRolesParams{
+		&service.ServiceDeps{Db: auth.Db}).GetAppuserRoles(qx.GetAppuserRolesParams{
 		AppserverID: obj.ID,
 		AppuserID:   userId,
 	})

--- a/src/permission/shared_test.go
+++ b/src/permission/shared_test.go
@@ -21,11 +21,7 @@ func TestSharedAuthorizer_UserIsServerOwner(t *testing.T) {
 		// ARRANGE
 		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
-		server := qx.Appserver{
-			ID:        uuid.New(),
-			Name:      "foo",
-			AppuserID: userID,
-		}
+		server := qx.Appserver{ID: uuid.New(), Name: "foo", AppuserID: userID}
 
 		mockQuerier := new(testutil.MockQuerier)
 		mockQuerier.On("GetAppserverById", mock.Anything, server.ID).Return(server, nil)
@@ -45,10 +41,7 @@ func TestSharedAuthorizer_UserIsServerOwner(t *testing.T) {
 		// ARRANGE
 		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
-		server := qx.Appserver{
-			ID:   uuid.New(),
-			Name: "foo",
-		}
+		server := qx.Appserver{ID: uuid.New(), Name: "foo"}
 
 		mockQuerier := new(testutil.MockQuerier)
 		mockQuerier.On("GetAppserverById", mock.Anything, server.ID).Return(server, nil)
@@ -68,9 +61,7 @@ func TestSharedAuthorizer_UserIsServerOwner(t *testing.T) {
 		// ARRANGE
 		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
-		server := qx.Appserver{
-			ID: uuid.New(),
-		}
+		server := qx.Appserver{ID: uuid.New()}
 
 		mockQuerier := new(testutil.MockQuerier)
 		mockQuerier.On("GetAppserverById", mock.Anything, server.ID).Return(qx.Appserver{}, fmt.Errorf("db fail"))
@@ -94,11 +85,7 @@ func TestSharedAuthorizer_UserHasServerSub(t *testing.T) {
 		// ARRANGE
 		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
-		server := qx.Appserver{
-			ID:        uuid.New(),
-			AppuserID: userID,
-			Name:      "foo",
-		}
+		server := qx.Appserver{ID: uuid.New()}
 
 		mockQuerier := new(testutil.MockQuerier)
 		mockQuerier.On("FilterAppserverSub", ctx, qx.FilterAppserverSubParams{
@@ -129,9 +116,7 @@ func TestSharedAuthorizer_UserHasServerSub(t *testing.T) {
 		// ARRANGE
 		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
-		server := qx.Appserver{
-			ID: uuid.New(),
-		}
+		server := qx.Appserver{ID: uuid.New()}
 
 		mockQuerier := new(testutil.MockQuerier)
 		mockQuerier.On("FilterAppserverSub", mock.Anything, qx.FilterAppserverSubParams{
@@ -154,11 +139,7 @@ func TestSharedAuthorizer_UserHasServerSub(t *testing.T) {
 		// ARRANGE
 		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
-		server := qx.Appserver{
-			ID:        uuid.New(),
-			Name:      "foo",
-			AppuserID: userID,
-		}
+		server := qx.Appserver{ID: uuid.New()}
 
 		mockQuerier := new(testutil.MockQuerier)
 		mockQuerier.On("FilterAppserverSub", ctx, qx.FilterAppserverSubParams{

--- a/src/permission/shared_test.go
+++ b/src/permission/shared_test.go
@@ -19,7 +19,7 @@ import (
 func TestSharedAuthorizer_UserIsServerOwner(t *testing.T) {
 	t.Run("Success:user_is_owner", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
 		server := qx.Appserver{
 			ID:        uuid.New(),
@@ -30,7 +30,7 @@ func TestSharedAuthorizer_UserIsServerOwner(t *testing.T) {
 		mockQuerier := new(testutil.MockQuerier)
 		mockQuerier.On("GetAppserverById", mock.Anything, server.ID).Return(server, nil)
 
-		auth := permission.NewSharedAuthorizer(testutil.TestDbConn, mockQuerier)
+		auth := permission.NewSharedAuthorizer(mockQuerier)
 
 		// ACT
 		isOwner, err := auth.UserIsServerOwner(ctx, userID, server.ID)
@@ -43,7 +43,7 @@ func TestSharedAuthorizer_UserIsServerOwner(t *testing.T) {
 
 	t.Run("Success:user_is_not_owner", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
 		server := qx.Appserver{
 			ID:   uuid.New(),
@@ -53,7 +53,7 @@ func TestSharedAuthorizer_UserIsServerOwner(t *testing.T) {
 		mockQuerier := new(testutil.MockQuerier)
 		mockQuerier.On("GetAppserverById", mock.Anything, server.ID).Return(server, nil)
 
-		auth := permission.NewSharedAuthorizer(testutil.TestDbConn, mockQuerier)
+		auth := permission.NewSharedAuthorizer(mockQuerier)
 
 		// ACT
 		isOwner, err := auth.UserIsServerOwner(ctx, userID, server.ID)
@@ -66,7 +66,7 @@ func TestSharedAuthorizer_UserIsServerOwner(t *testing.T) {
 
 	t.Run("Error:on_db_failure", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
 		server := qx.Appserver{
 			ID: uuid.New(),
@@ -75,7 +75,7 @@ func TestSharedAuthorizer_UserIsServerOwner(t *testing.T) {
 		mockQuerier := new(testutil.MockQuerier)
 		mockQuerier.On("GetAppserverById", mock.Anything, server.ID).Return(qx.Appserver{}, fmt.Errorf("db fail"))
 
-		auth := permission.NewSharedAuthorizer(testutil.TestDbConn, mockQuerier)
+		auth := permission.NewSharedAuthorizer(mockQuerier)
 
 		// ACT
 		isOwner, err := auth.UserIsServerOwner(ctx, userID, server.ID)
@@ -92,7 +92,7 @@ func TestSharedAuthorizer_UserIsServerOwner(t *testing.T) {
 func TestSharedAuthorizer_UserHasServerSub(t *testing.T) {
 	t.Run("Success:user_has_sub", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
 		server := qx.Appserver{
 			ID:        uuid.New(),
@@ -114,7 +114,7 @@ func TestSharedAuthorizer_UserHasServerSub(t *testing.T) {
 			},
 		}, nil)
 
-		auth := permission.NewSharedAuthorizer(testutil.TestDbConn, mockQuerier)
+		auth := permission.NewSharedAuthorizer(mockQuerier)
 
 		// ACT
 		hasSub, err := auth.UserHasServerSub(ctx, userID, server.ID)
@@ -127,7 +127,7 @@ func TestSharedAuthorizer_UserHasServerSub(t *testing.T) {
 
 	t.Run("Success:user_does_not_have_sub", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
 		server := qx.Appserver{
 			ID: uuid.New(),
@@ -139,7 +139,7 @@ func TestSharedAuthorizer_UserHasServerSub(t *testing.T) {
 			AppuserID:   pgtype.UUID{Valid: true, Bytes: userID},
 		}).Return([]qx.FilterAppserverSubRow{}, nil)
 
-		auth := permission.NewSharedAuthorizer(testutil.TestDbConn, mockQuerier)
+		auth := permission.NewSharedAuthorizer(mockQuerier)
 
 		// ACT
 		hasSub, err := auth.UserHasServerSub(ctx, userID, server.ID)
@@ -152,7 +152,7 @@ func TestSharedAuthorizer_UserHasServerSub(t *testing.T) {
 
 	t.Run("Error:on_db_failure", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
 		server := qx.Appserver{
 			ID:        uuid.New(),
@@ -166,7 +166,7 @@ func TestSharedAuthorizer_UserHasServerSub(t *testing.T) {
 			AppuserID:   pgtype.UUID{Valid: true, Bytes: userID},
 		}).Return(nil, fmt.Errorf("db error"))
 
-		auth := permission.NewSharedAuthorizer(testutil.TestDbConn, mockQuerier)
+		auth := permission.NewSharedAuthorizer(mockQuerier)
 
 		// ACT
 		hasSub, err := auth.UserHasServerSub(ctx, userID, server.ID)

--- a/src/psql_db/db/querier.go
+++ b/src/psql_db/db/querier.go
@@ -1,28 +1,92 @@
 package db
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
+	"mist/src/faults"
 	"mist/src/psql_db/qx"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+type DBTX interface {
+	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...interface{}) pgx.Row
+}
 
 type Querier interface {
 	qx.Querier
-	WithTx(tx pgx.Tx) Querier
+	Begin(ctx context.Context) (Querier, error)
+	Commit(ctx context.Context) error
+	Rollback(ctx context.Context) error
 }
 
 type Queries struct {
 	*qx.Queries
+	dbConn DBTX
 }
 
-func (q *Queries) WithTx(tx pgx.Tx) Querier {
+func (q *Queries) Begin(ctx context.Context) (Querier, error) {
+	db, ok := q.dbConn.(*pgxpool.Pool)
+
+	if !ok {
+		// If dbConn is already a transaction, return the same querier
+		if _, ok := q.dbConn.(pgx.Tx); ok {
+			return q, nil
+		}
+
+		return nil, faults.DatabaseError(
+			"querier's dbConn is not a pgxpool.Pool or pgx.Tx, cannot begin transaction", slog.LevelError,
+		)
+	}
+
+	// Begin a new transaction
+	tx, err := db.Begin(ctx)
+
+	if err != nil {
+		return nil, faults.DatabaseError(fmt.Sprintf("failed to begin transaction %v", err), slog.LevelError)
+	}
+
+	// Return a new Queries instance with the transaction
 	return &Queries{
 		Queries: q.Queries.WithTx(tx),
-	}
+		dbConn:  tx,
+	}, nil
 }
 
-func NewQuerier(q *qx.Queries) Querier {
+func (q *Queries) Commit(ctx context.Context) error {
+	tx, ok := q.dbConn.(pgx.Tx)
+	if !ok {
+		return faults.DatabaseError("querier's dbConn is not a transaction, cannot commit", slog.LevelError)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return faults.DatabaseError(fmt.Sprintf("failed to commit transaction %v", err), slog.LevelError)
+	}
+
+	return nil
+}
+
+func (q *Queries) Rollback(ctx context.Context) error {
+	tx, ok := q.dbConn.(pgx.Tx)
+	if !ok {
+		return faults.DatabaseError("querier's dbConn is not a transaction, cannot rollback", slog.LevelError)
+	}
+
+	if err := tx.Rollback(ctx); err != nil {
+		return faults.DatabaseError(fmt.Sprintf("failed to rollback transaction %v", err), slog.LevelError)
+	}
+
+	return nil
+}
+
+func NewQuerier(dbConn DBTX) Querier {
 	return &Queries{
-		Queries: q,
+		Queries: qx.New(dbConn),
+		dbConn:  dbConn,
 	}
 }

--- a/src/psql_db/migrations/20241227234305_add_appserver_sub_table.sql
+++ b/src/psql_db/migrations/20241227234305_add_appserver_sub_table.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS appserver_sub (
     FOREIGN KEY (appserver_id) REFERENCES appserver(id) ON DELETE CASCADE,
     FOREIGN KEY (appuser_id) REFERENCES appuser(id) ON DELETE CASCADE,
 
-    CONSTRAINT appserver_sub_uk_appserver_owner UNIQUE (appserver_id, appuser_id),
+    CONSTRAINT appserver_sub_uk_appserver_user UNIQUE (appserver_id, appuser_id),
     CONSTRAINT appserver_sub_uk_server_sub UNIQUE (appserver_id, id)
 );
 -- +goose StatementEnd

--- a/src/psql_db/qx/appserver_role_sub_test.go
+++ b/src/psql_db/qx/appserver_role_sub_test.go
@@ -14,12 +14,13 @@ import (
 func TestQuerier_ListServerRoleSubs(t *testing.T) {
 	t.Run("Success:list_role_subs_by_appserver", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		role1 := testutil.TestAppserverRoleSub(t, nil, false)
-		testutil.TestAppserverRoleSub(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		f := factory.NewFactory(ctx, db)
+		role1 := f.AppserverRoleSub(t, 0, nil)
+		f.AppserverRoleSub(t, 0, nil)
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).ListServerRoleSubs(ctx, role1.AppserverID)
+		results, err := db.ListServerRoleSubs(ctx, role1.AppserverID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -33,10 +34,10 @@ func TestQuerier_CreateAppserverRoleSub(t *testing.T) {
 		// ARRANGE
 		ctx, db := testutil.Setup(t, func() {})
 		su := factory.UserAppserverSub(t, ctx, db)
-		role1 := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "foo", AppserverID: su.Server.ID}, false)
+		role1 := factory.NewFactory(ctx, db).AppserverRole(t, 0, nil)
 
 		// ACT
-		r, err := qx.New(testutil.TestDbConn).CreateAppserverRoleSub(ctx, qx.CreateAppserverRoleSubParams{
+		r, err := db.CreateAppserverRoleSub(ctx, qx.CreateAppserverRoleSubParams{
 			AppserverSubID:  su.Sub.ID,
 			AppserverRoleID: role1.ID,
 			AppuserID:       su.User.ID,
@@ -51,16 +52,17 @@ func TestQuerier_CreateAppserverRoleSub(t *testing.T) {
 	t.Run("Error:when_appserver_sub_and_appserver_role_dont_belong_to_same_server_it_errors", func(t *testing.T) {
 		// ARRANGE
 		ctx, db := testutil.Setup(t, func() {})
-		user := testutil.TestAppuser(t, nil, false)
-		su := factory.UserAppserverSub(t, ctx, db)
-		role1 := testutil.TestAppserverRole(t, nil, false)
+		f := factory.NewFactory(ctx, db)
+		user := f.Appuser(t, 0, nil)
+		sub := f.AppserverSub(t, 0, nil)
+		role := f.AppserverRole(t, 1, nil)
 
 		// ACT
-		_, err := qx.New(testutil.TestDbConn).CreateAppserverRoleSub(ctx, qx.CreateAppserverRoleSubParams{
-			AppserverSubID:  su.Sub.ID,
-			AppserverRoleID: role1.ID,
+		_, err := db.CreateAppserverRoleSub(ctx, qx.CreateAppserverRoleSubParams{
+			AppserverSubID:  sub.ID,
+			AppserverRoleID: role.ID,
 			AppuserID:       user.ID,
-			AppserverID:     role1.AppserverID,
+			AppserverID:     role.AppserverID,
 		})
 
 		// ASSERT
@@ -72,11 +74,11 @@ func TestQuerier_CreateAppserverRoleSub(t *testing.T) {
 func TestQuerier_GetById(t *testing.T) {
 	t.Run("Success:get_appserver_role_sub_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		role1 := testutil.TestAppserverRoleSub(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		role1 := factory.NewFactory(ctx, db).AppserverRoleSub(t, 0, nil)
 
 		// ACT
-		result, err := qx.New(testutil.TestDbConn).GetAppserverRoleSubById(ctx, role1.ID)
+		result, err := db.GetAppserverRoleSubById(ctx, role1.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -86,11 +88,11 @@ func TestQuerier_GetById(t *testing.T) {
 
 	t.Run("Error:when_appserver_role_sub_does_not_exist_it_returns_error", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		id := uuid.New()
 
 		// ACT
-		_, err := qx.New(testutil.TestDbConn).GetAppserverRoleSubById(ctx, id)
+		_, err := db.GetAppserverRoleSubById(ctx, id)
 
 		// ASSERT
 		assert.Error(t, err)
@@ -102,11 +104,11 @@ func TestQuerier_GetById(t *testing.T) {
 func TestQuerier_DeleteAppserverRoleSub(t *testing.T) {
 	t.Run("Success:delete_appserver_role_sub", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		role1 := testutil.TestAppserverRoleSub(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		role1 := factory.NewFactory(ctx, db).AppserverRoleSub(t, 0, nil)
 
 		// ACT
-		count, err := qx.New(testutil.TestDbConn).DeleteAppserverRoleSub(ctx, role1.ID)
+		count, err := db.DeleteAppserverRoleSub(ctx, role1.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -115,11 +117,11 @@ func TestQuerier_DeleteAppserverRoleSub(t *testing.T) {
 
 	t.Run("Error:when_appserver_role_sub_does_not_exist_it_returns_zero_count", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		id := uuid.New()
 
 		// ACT
-		count, _ := qx.New(testutil.TestDbConn).DeleteAppserverRoleSub(ctx, id)
+		count, _ := db.DeleteAppserverRoleSub(ctx, id)
 
 		// ASSERT
 		assert.Equal(t, int64(0), count)
@@ -129,8 +131,8 @@ func TestQuerier_DeleteAppserverRoleSub(t *testing.T) {
 func TestQuerier_FilterAppserverRoleSub(t *testing.T) {
 	t.Run("Success:filter_by_all_fields", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		roleSub := testutil.TestAppserverRoleSub(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		roleSub := factory.NewFactory(ctx, db).AppserverRoleSub(t, 0, nil)
 
 		params := qx.FilterAppserverRoleSubParams{
 			AppuserID:       pgtype.UUID{Bytes: roleSub.AppuserID, Valid: true},
@@ -140,7 +142,7 @@ func TestQuerier_FilterAppserverRoleSub(t *testing.T) {
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).FilterAppserverRoleSub(ctx, params)
+		results, err := db.FilterAppserverRoleSub(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -150,8 +152,8 @@ func TestQuerier_FilterAppserverRoleSub(t *testing.T) {
 
 	t.Run("Success:filter_by_partial_fields", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		roleSub := testutil.TestAppserverRoleSub(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		roleSub := factory.NewFactory(ctx, db).AppserverRoleSub(t, 0, nil)
 
 		params := qx.FilterAppserverRoleSubParams{
 			AppuserID:       pgtype.UUID{Bytes: roleSub.AppuserID, Valid: true},
@@ -161,7 +163,7 @@ func TestQuerier_FilterAppserverRoleSub(t *testing.T) {
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).FilterAppserverRoleSub(ctx, params)
+		results, err := db.FilterAppserverRoleSub(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -170,8 +172,8 @@ func TestQuerier_FilterAppserverRoleSub(t *testing.T) {
 
 	t.Run("EmptyResult:when_filter_does_not_match", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		_ = testutil.TestAppserverRoleSub(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		_ = factory.NewFactory(ctx, db).AppserverRoleSub(t, 0, nil)
 
 		params := qx.FilterAppserverRoleSubParams{
 			AppuserID:       pgtype.UUID{Bytes: uuid.New(), Valid: true},
@@ -181,7 +183,7 @@ func TestQuerier_FilterAppserverRoleSub(t *testing.T) {
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).FilterAppserverRoleSub(ctx, params)
+		results, err := db.FilterAppserverRoleSub(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)

--- a/src/psql_db/qx/appserver_role_sub_test.go
+++ b/src/psql_db/qx/appserver_role_sub_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestQuerier_ListServerRoleSubs(t *testing.T) {
-	t.Run("Successlist_role_subs_by_appserver", func(t *testing.T) {
+	t.Run("Success:list_role_subs_by_appserver", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		role1 := testutil.TestAppserverRoleSub(t, nil, false)
 		testutil.TestAppserverRoleSub(t, nil, false)
 
@@ -29,10 +29,10 @@ func TestQuerier_ListServerRoleSubs(t *testing.T) {
 }
 
 func TestQuerier_CreateAppserverRoleSub(t *testing.T) {
-	t.Run("Successcreate_appserver_role_sub", func(t *testing.T) {
+	t.Run("Success:create_appserver_role_sub", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
-		su := factory.UserAppserverSub(t)
+		ctx, db := testutil.Setup(t, func() {})
+		su := factory.UserAppserverSub(t, ctx, db)
 		role1 := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "foo", AppserverID: su.Server.ID}, false)
 
 		// ACT
@@ -50,9 +50,9 @@ func TestQuerier_CreateAppserverRoleSub(t *testing.T) {
 
 	t.Run("Error:when_appserver_sub_and_appserver_role_dont_belong_to_same_server_it_errors", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		user := testutil.TestAppuser(t, nil, false)
-		su := factory.UserAppserverSub(t)
+		su := factory.UserAppserverSub(t, ctx, db)
 		role1 := testutil.TestAppserverRole(t, nil, false)
 
 		// ACT
@@ -70,9 +70,9 @@ func TestQuerier_CreateAppserverRoleSub(t *testing.T) {
 }
 
 func TestQuerier_GetById(t *testing.T) {
-	t.Run("Successget_appserver_role_sub_by_id", func(t *testing.T) {
+	t.Run("Success:get_appserver_role_sub_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		role1 := testutil.TestAppserverRoleSub(t, nil, false)
 
 		// ACT
@@ -86,7 +86,7 @@ func TestQuerier_GetById(t *testing.T) {
 
 	t.Run("Error:when_appserver_role_sub_does_not_exist_it_returns_error", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		id := uuid.New()
 
 		// ACT
@@ -100,9 +100,9 @@ func TestQuerier_GetById(t *testing.T) {
 }
 
 func TestQuerier_DeleteAppserverRoleSub(t *testing.T) {
-	t.Run("Successdelete_appserver_role_sub", func(t *testing.T) {
+	t.Run("Success:delete_appserver_role_sub", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		role1 := testutil.TestAppserverRoleSub(t, nil, false)
 
 		// ACT
@@ -115,7 +115,7 @@ func TestQuerier_DeleteAppserverRoleSub(t *testing.T) {
 
 	t.Run("Error:when_appserver_role_sub_does_not_exist_it_returns_zero_count", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		id := uuid.New()
 
 		// ACT
@@ -127,9 +127,9 @@ func TestQuerier_DeleteAppserverRoleSub(t *testing.T) {
 }
 
 func TestQuerier_FilterAppserverRoleSub(t *testing.T) {
-	t.Run("Successfilter_by_all_fields", func(t *testing.T) {
+	t.Run("Success:filter_by_all_fields", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		roleSub := testutil.TestAppserverRoleSub(t, nil, false)
 
 		params := qx.FilterAppserverRoleSubParams{
@@ -148,9 +148,9 @@ func TestQuerier_FilterAppserverRoleSub(t *testing.T) {
 		assert.Equal(t, roleSub.ID, results[0].ID)
 	})
 
-	t.Run("Successfilter_by_partial_fields", func(t *testing.T) {
+	t.Run("Success:filter_by_partial_fields", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		roleSub := testutil.TestAppserverRoleSub(t, nil, false)
 
 		params := qx.FilterAppserverRoleSubParams{
@@ -170,7 +170,7 @@ func TestQuerier_FilterAppserverRoleSub(t *testing.T) {
 
 	t.Run("EmptyResult:when_filter_does_not_match", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		_ = testutil.TestAppserverRoleSub(t, nil, false)
 
 		params := qx.FilterAppserverRoleSubParams{

--- a/src/psql_db/qx/appserver_role_test.go
+++ b/src/psql_db/qx/appserver_role_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestQuerier_CreateAppserverRole(t *testing.T) {
-	t.Run("Successcreate_appserver_role", func(t *testing.T) {
+	t.Run("Success:create_appserver_role", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		server := testutil.TestAppserver(t, nil, false)
 		params := qx.CreateAppserverRoleParams{
 			AppserverID:             server.ID,
@@ -35,9 +35,9 @@ func TestQuerier_CreateAppserverRole(t *testing.T) {
 }
 
 func TestQuerier_GetAppserverRoleById(t *testing.T) {
-	t.Run("Successget_appserver_role_by_id", func(t *testing.T) {
+	t.Run("Success:get_appserver_role_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		role := testutil.TestAppserverRole(t, nil, false)
 
 		// ACT
@@ -50,7 +50,7 @@ func TestQuerier_GetAppserverRoleById(t *testing.T) {
 
 	t.Run("Error:role_does_not_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		// ACT
 		_, err := qx.New(testutil.TestDbConn).GetAppserverRoleById(ctx, uuid.New())
 
@@ -61,9 +61,9 @@ func TestQuerier_GetAppserverRoleById(t *testing.T) {
 }
 
 func TestQuerier_DeleteAppserverRole(t *testing.T) {
-	t.Run("Successdelete_appserver_role", func(t *testing.T) {
+	t.Run("Success:delete_appserver_role", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		role := testutil.TestAppserverRole(t, nil, false)
 
 		// ACT
@@ -76,7 +76,7 @@ func TestQuerier_DeleteAppserverRole(t *testing.T) {
 
 	t.Run("Error:role_does_not_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		// ACT
 		count, err := qx.New(testutil.TestDbConn).DeleteAppserverRole(ctx, uuid.New())
 
@@ -85,10 +85,10 @@ func TestQuerier_DeleteAppserverRole(t *testing.T) {
 		assert.Equal(t, int64(0), count)
 	})
 
-	t.Run("Successdeleting_appserver_role_removes_associated_appserver_role_subs", func(t *testing.T) {
+	t.Run("Success:deleting_appserver_role_removes_associated_appserver_role_subs", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
-		su := factory.UserAppserverSub(t)
+		ctx, db := testutil.Setup(t, func() {})
+		su := factory.UserAppserverSub(t, ctx, db)
 		role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "test_role", AppserverID: su.Server.ID}, false)
 		rolesub := testutil.TestAppserverRoleSub(t, &qx.AppserverRoleSub{
 			AppuserID:       su.User.ID,
@@ -109,10 +109,10 @@ func TestQuerier_DeleteAppserverRole(t *testing.T) {
 		assert.Contains(t, err.Error(), "no rows in result set")
 	})
 
-	t.Run("Successdeleting_appserver_role_removes_associated_channel_roles", func(t *testing.T) {
+	t.Run("Success:deleting_appserver_role_removes_associated_channel_roles", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
-		su := factory.UserAppserverSub(t)
+		ctx, db := testutil.Setup(t, func() {})
+		su := factory.UserAppserverSub(t, ctx, db)
 		role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "test_role", AppserverID: su.Server.ID}, false)
 		channel := testutil.TestChannel(t, &qx.Channel{AppserverID: role.AppserverID, Name: "c1", IsPrivate: true}, false)
 		channelRole := testutil.TestChannelRole(t, &qx.ChannelRole{
@@ -137,9 +137,9 @@ func TestQuerier_DeleteAppserverRole(t *testing.T) {
 }
 
 func TestQuerier_ListAppserverRoles(t *testing.T) {
-	t.Run("Successlist_appserver_roles", func(t *testing.T) {
+	t.Run("Success:list_appserver_roles", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		role := testutil.TestAppserverRole(t, nil, false)
 
 		// ACT
@@ -152,7 +152,7 @@ func TestQuerier_ListAppserverRoles(t *testing.T) {
 
 	t.Run("Error:when_no_roles_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		appserverID := uuid.New()
 
 		// ACT
@@ -165,10 +165,10 @@ func TestQuerier_ListAppserverRoles(t *testing.T) {
 }
 
 func TestQuerier_GetAppuserRoles(t *testing.T) {
-	t.Run("Successget_appuser_roles", func(t *testing.T) {
+	t.Run("Success:get_appuser_roles", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
-		su := factory.UserAppserverSub(t)
+		ctx, db := testutil.Setup(t, func() {})
+		su := factory.UserAppserverSub(t, ctx, db)
 		role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "mod", AppserverID: su.Server.ID}, false)
 		testutil.TestAppserverRoleSub(t, &qx.AppserverRoleSub{
 			AppuserID: su.User.ID, AppserverID: su.Server.ID,
@@ -189,7 +189,7 @@ func TestQuerier_GetAppuserRoles(t *testing.T) {
 
 	t.Run("Error:get_appuser_roles_for_nonexistent_user", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		nonexistentUserID := uuid.New()
 		appserverID := uuid.New()
 
@@ -207,10 +207,10 @@ func TestQuerier_GetAppuserRoles(t *testing.T) {
 }
 
 func TestQuerier_GetAppusersWithOnlySpecifiedRole(t *testing.T) {
-	t.Run("Successget_users_with_only_specified_role", func(t *testing.T) {
+	t.Run("Success:get_users_with_only_specified_role", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
-		su := factory.UserAppserverSub(t)
+		ctx, db := testutil.Setup(t, func() {})
+		su := factory.UserAppserverSub(t, ctx, db)
 		role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "solo", AppserverID: su.Server.ID}, false)
 
 		testutil.TestAppserverRoleSub(t, &qx.AppserverRoleSub{
@@ -229,7 +229,7 @@ func TestQuerier_GetAppusersWithOnlySpecifiedRole(t *testing.T) {
 
 	t.Run("Error:get_users_with_only_specified_role_no_users", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		role := testutil.TestAppserverRole(t, nil, false)
 
 		// ACT

--- a/src/psql_db/qx/appserver_role_test.go
+++ b/src/psql_db/qx/appserver_role_test.go
@@ -166,7 +166,12 @@ func TestQuerier_GetAppuserRoles(t *testing.T) {
 		su := factory.UserAppserverSub(t, ctx, db)
 		f := factory.NewFactory(ctx, db)
 		role := f.AppserverRole(t, 0, nil)
-		f.AppserverRoleSub(t, 0, nil)
+		f.AppserverRoleSub(t, 0, &qx.AppserverRoleSub{
+			AppuserID:       su.User.ID,
+			AppserverID:     su.Server.ID,
+			AppserverRoleID: role.ID,
+			AppserverSubID:  su.Sub.ID,
+		})
 
 		// ACT
 		roles, err := db.GetAppuserRoles(ctx, qx.GetAppuserRolesParams{
@@ -206,7 +211,12 @@ func TestQuerier_GetAppusersWithOnlySpecifiedRole(t *testing.T) {
 		su := factory.UserAppserverSub(t, ctx, db)
 		f := factory.NewFactory(ctx, db)
 		role := f.AppserverRole(t, 0, nil)
-		factory.NewFactory(ctx, db).AppserverRoleSub(t, 0, nil)
+		factory.NewFactory(ctx, db).AppserverRoleSub(t, 0, &qx.AppserverRoleSub{
+			AppuserID:       su.User.ID,
+			AppserverID:     su.Server.ID,
+			AppserverRoleID: role.ID,
+			AppserverSubID:  su.Sub.ID,
+		})
 
 		// ACT
 		users, err := db.GetAppusersWithOnlySpecifiedRole(ctx, role.ID)

--- a/src/psql_db/qx/appserver_role_test.go
+++ b/src/psql_db/qx/appserver_role_test.go
@@ -14,8 +14,8 @@ import (
 func TestQuerier_CreateAppserverRole(t *testing.T) {
 	t.Run("Success:create_appserver_role", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		server := testutil.TestAppserver(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		server := factory.NewFactory(ctx, db).Appserver(t, 0, nil)
 		params := qx.CreateAppserverRoleParams{
 			AppserverID:             server.ID,
 			Name:                    "Admin",
@@ -25,7 +25,7 @@ func TestQuerier_CreateAppserverRole(t *testing.T) {
 		}
 
 		// ACT
-		role, err := qx.New(testutil.TestDbConn).CreateAppserverRole(ctx, params)
+		role, err := db.CreateAppserverRole(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -37,11 +37,11 @@ func TestQuerier_CreateAppserverRole(t *testing.T) {
 func TestQuerier_GetAppserverRoleById(t *testing.T) {
 	t.Run("Success:get_appserver_role_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		role := testutil.TestAppserverRole(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		role := factory.NewFactory(ctx, db).AppserverRole(t, 0, nil)
 
 		// ACT
-		result, err := qx.New(testutil.TestDbConn).GetAppserverRoleById(ctx, role.ID)
+		result, err := db.GetAppserverRoleById(ctx, role.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -50,9 +50,10 @@ func TestQuerier_GetAppserverRoleById(t *testing.T) {
 
 	t.Run("Error:role_does_not_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
+
 		// ACT
-		_, err := qx.New(testutil.TestDbConn).GetAppserverRoleById(ctx, uuid.New())
+		_, err := db.GetAppserverRoleById(ctx, uuid.New())
 
 		// ASSERT
 		assert.Error(t, err)
@@ -63,11 +64,11 @@ func TestQuerier_GetAppserverRoleById(t *testing.T) {
 func TestQuerier_DeleteAppserverRole(t *testing.T) {
 	t.Run("Success:delete_appserver_role", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		role := testutil.TestAppserverRole(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		role := factory.NewFactory(ctx, db).AppserverRole(t, 0, nil)
 
 		// ACT
-		count, err := qx.New(testutil.TestDbConn).DeleteAppserverRole(ctx, role.ID)
+		count, err := db.DeleteAppserverRole(ctx, role.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -76,9 +77,10 @@ func TestQuerier_DeleteAppserverRole(t *testing.T) {
 
 	t.Run("Error:role_does_not_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
+
 		// ACT
-		count, err := qx.New(testutil.TestDbConn).DeleteAppserverRole(ctx, uuid.New())
+		count, err := db.DeleteAppserverRole(ctx, uuid.New())
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -88,23 +90,19 @@ func TestQuerier_DeleteAppserverRole(t *testing.T) {
 	t.Run("Success:deleting_appserver_role_removes_associated_appserver_role_subs", func(t *testing.T) {
 		// ARRANGE
 		ctx, db := testutil.Setup(t, func() {})
-		su := factory.UserAppserverSub(t, ctx, db)
-		role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "test_role", AppserverID: su.Server.ID}, false)
-		rolesub := testutil.TestAppserverRoleSub(t, &qx.AppserverRoleSub{
-			AppuserID:       su.User.ID,
-			AppserverID:     role.AppserverID,
-			AppserverRoleID: role.ID,
-			AppserverSubID:  su.Sub.ID,
-		}, false)
+		f := factory.NewFactory(ctx, db)
+		f.AppserverSub(t, 0, nil)
+		role := f.AppserverRole(t, 0, nil)
+		roleSub := f.AppserverRoleSub(t, 0, nil)
 
 		// ACT
-		count, err := qx.New(testutil.TestDbConn).DeleteAppserverRole(ctx, role.ID)
+		count, err := db.DeleteAppserverRole(ctx, role.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), count)
 		// Verify that the associated AppserverRoleSub is also deleted
-		_, err = qx.New(testutil.TestDbConn).GetAppserverRoleSubById(ctx, rolesub.ID)
+		_, err = db.GetAppserverRoleSubById(ctx, roleSub.ID)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no rows in result set")
 	})
@@ -112,24 +110,21 @@ func TestQuerier_DeleteAppserverRole(t *testing.T) {
 	t.Run("Success:deleting_appserver_role_removes_associated_channel_roles", func(t *testing.T) {
 		// ARRANGE
 		ctx, db := testutil.Setup(t, func() {})
-		su := factory.UserAppserverSub(t, ctx, db)
-		role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "test_role", AppserverID: su.Server.ID}, false)
-		channel := testutil.TestChannel(t, &qx.Channel{AppserverID: role.AppserverID, Name: "c1", IsPrivate: true}, false)
-		channelRole := testutil.TestChannelRole(t, &qx.ChannelRole{
-			AppserverID:     role.AppserverID,
-			AppserverRoleID: role.ID,
-			ChannelID:       channel.ID,
-		}, false)
+		f := factory.NewFactory(ctx, db)
+		sub := f.AppserverSub(t, 0, nil)
+		role := f.AppserverRole(t, 0, nil)
+		f.Channel(t, 0, &qx.Channel{Name: "foo", AppserverID: sub.AppserverID, IsPrivate: true})
+		channelRole := f.ChannelRole(t, 0, nil)
 
 		// ACT
-		count, err := qx.New(testutil.TestDbConn).DeleteAppserverRole(ctx, role.ID)
+		count, err := db.DeleteAppserverRole(ctx, role.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), count)
 
 		// Verify that the associated AppserverRoleSub is also deleted
-		_, err = qx.New(testutil.TestDbConn).GetAppserverRoleSubById(ctx, channelRole.ID)
+		_, err = db.GetAppserverRoleSubById(ctx, channelRole.ID)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no rows in result set")
 	})
@@ -139,11 +134,11 @@ func TestQuerier_DeleteAppserverRole(t *testing.T) {
 func TestQuerier_ListAppserverRoles(t *testing.T) {
 	t.Run("Success:list_appserver_roles", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		role := testutil.TestAppserverRole(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		role := factory.NewFactory(ctx, db).AppserverRole(t, 0, nil)
 
 		// ACT
-		roles, err := qx.New(testutil.TestDbConn).ListAppserverRoles(ctx, role.AppserverID)
+		roles, err := db.ListAppserverRoles(ctx, role.AppserverID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -152,11 +147,11 @@ func TestQuerier_ListAppserverRoles(t *testing.T) {
 
 	t.Run("Error:when_no_roles_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		appserverID := uuid.New()
 
 		// ACT
-		roles, err := qx.New(testutil.TestDbConn).ListAppserverRoles(ctx, appserverID)
+		roles, err := db.ListAppserverRoles(ctx, appserverID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -169,14 +164,12 @@ func TestQuerier_GetAppuserRoles(t *testing.T) {
 		// ARRANGE
 		ctx, db := testutil.Setup(t, func() {})
 		su := factory.UserAppserverSub(t, ctx, db)
-		role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "mod", AppserverID: su.Server.ID}, false)
-		testutil.TestAppserverRoleSub(t, &qx.AppserverRoleSub{
-			AppuserID: su.User.ID, AppserverID: su.Server.ID,
-			AppserverSubID: su.Sub.ID, AppserverRoleID: role.ID,
-		}, false)
+		f := factory.NewFactory(ctx, db)
+		role := f.AppserverRole(t, 0, nil)
+		f.AppserverRoleSub(t, 0, nil)
 
 		// ACT
-		roles, err := qx.New(testutil.TestDbConn).GetAppuserRoles(ctx, qx.GetAppuserRolesParams{
+		roles, err := db.GetAppuserRoles(ctx, qx.GetAppuserRolesParams{
 			AppuserID:   su.User.ID,
 			AppserverID: su.Server.ID,
 		})
@@ -189,12 +182,12 @@ func TestQuerier_GetAppuserRoles(t *testing.T) {
 
 	t.Run("Error:get_appuser_roles_for_nonexistent_user", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		nonexistentUserID := uuid.New()
 		appserverID := uuid.New()
 
 		// ACT
-		roles, err := qx.New(testutil.TestDbConn).GetAppuserRoles(ctx, qx.GetAppuserRolesParams{
+		roles, err := db.GetAppuserRoles(ctx, qx.GetAppuserRolesParams{
 			AppuserID:   nonexistentUserID,
 			AppserverID: appserverID,
 		})
@@ -211,15 +204,12 @@ func TestQuerier_GetAppusersWithOnlySpecifiedRole(t *testing.T) {
 		// ARRANGE
 		ctx, db := testutil.Setup(t, func() {})
 		su := factory.UserAppserverSub(t, ctx, db)
-		role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "solo", AppserverID: su.Server.ID}, false)
-
-		testutil.TestAppserverRoleSub(t, &qx.AppserverRoleSub{
-			AppuserID: su.User.ID, AppserverRoleID: role.ID,
-			AppserverID: su.Server.ID, AppserverSubID: su.Sub.ID,
-		}, false)
+		f := factory.NewFactory(ctx, db)
+		role := f.AppserverRole(t, 0, nil)
+		factory.NewFactory(ctx, db).AppserverRoleSub(t, 0, nil)
 
 		// ACT
-		users, err := qx.New(testutil.TestDbConn).GetAppusersWithOnlySpecifiedRole(ctx, role.ID)
+		users, err := db.GetAppusersWithOnlySpecifiedRole(ctx, role.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -229,11 +219,11 @@ func TestQuerier_GetAppusersWithOnlySpecifiedRole(t *testing.T) {
 
 	t.Run("Error:get_users_with_only_specified_role_no_users", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		role := testutil.TestAppserverRole(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		role := factory.NewFactory(ctx, db).AppserverRole(t, 0, nil)
 
 		// ACT
-		users, err := qx.New(testutil.TestDbConn).GetAppusersWithOnlySpecifiedRole(ctx, role.ID)
+		users, err := db.GetAppusersWithOnlySpecifiedRole(ctx, role.ID)
 
 		// ASSERT
 		assert.NoError(t, err)

--- a/src/psql_db/qx/appserver_sub_test.go
+++ b/src/psql_db/qx/appserver_sub_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func TestQuerier_CreateAppserverSub(t *testing.T) {
-	t.Run("Successcreate_appserver_sub", func(t *testing.T) {
+	t.Run("Success:create_appserver_sub", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		user := testutil.TestAppuser(t, nil, false)
 		server := testutil.TestAppserver(t, nil, false)
 
@@ -35,9 +35,9 @@ func TestQuerier_CreateAppserverSub(t *testing.T) {
 }
 
 func TestQuerier_DeleteAppserverSub(t *testing.T) {
-	t.Run("Successdelete_appserver_sub", func(t *testing.T) {
+	t.Run("Success:delete_appserver_sub", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		sub := testutil.TestAppserverSub(t, nil, false)
 
 		// ACT
@@ -49,16 +49,16 @@ func TestQuerier_DeleteAppserverSub(t *testing.T) {
 	})
 
 	t.Run("Error:sub_does_not_exist", func(t *testing.T) {
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		count, err := qx.New(testutil.TestDbConn).DeleteAppserverSub(ctx, uuid.New())
 		assert.NoError(t, err)
 		assert.Equal(t, int64(0), count)
 	})
 
-	t.Run("Successdeleting_appserver_sub_deletes_appserver_role_subs", func(t *testing.T) {
+	t.Run("Success:deleting_appserver_sub_deletes_appserver_role_subs", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
-		su := factory.UserAppserverSub(t)
+		ctx, db := testutil.Setup(t, func() {})
+		su := factory.UserAppserverSub(t, ctx, db)
 		role := testutil.TestAppserverRole(t, &qx.AppserverRole{Name: "foo", AppserverID: su.Server.ID}, false)
 		_, err := qx.New(testutil.TestDbConn).CreateAppserverRoleSub(ctx, qx.CreateAppserverRoleSubParams{
 			AppuserID:       su.User.ID,
@@ -82,9 +82,9 @@ func TestQuerier_DeleteAppserverSub(t *testing.T) {
 }
 
 func TestQuerier_FilterAppserverSub(t *testing.T) {
-	t.Run("Successfilter_appserver_sub", func(t *testing.T) {
-		ctx := testutil.Setup(t, func() {})
-		su := factory.UserAppserverSub(t)
+	t.Run("Success:filter_appserver_sub", func(t *testing.T) {
+		ctx, db := testutil.Setup(t, func() {})
+		su := factory.UserAppserverSub(t, ctx, db)
 
 		params := qx.FilterAppserverSubParams{
 			AppuserID:   pgtype.UUID{Bytes: su.User.ID, Valid: true},
@@ -98,7 +98,7 @@ func TestQuerier_FilterAppserverSub(t *testing.T) {
 	})
 
 	t.Run("Error:invalid_filter_params", func(t *testing.T) {
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		params := qx.FilterAppserverSubParams{
 			AppuserID:   pgtype.UUID{Valid: false},
 			AppserverID: pgtype.UUID{Valid: false},
@@ -111,8 +111,8 @@ func TestQuerier_FilterAppserverSub(t *testing.T) {
 }
 
 func TestQuerier_GetAppserverSubById(t *testing.T) {
-	t.Run("Successget_appserver_sub_by_id", func(t *testing.T) {
-		ctx := testutil.Setup(t, func() {})
+	t.Run("Success:get_appserver_sub_by_id", func(t *testing.T) {
+		ctx, _ := testutil.Setup(t, func() {})
 		sub := testutil.TestAppserverSub(t, nil, false)
 
 		result, err := qx.New(testutil.TestDbConn).GetAppserverSubById(ctx, sub.ID)
@@ -122,16 +122,16 @@ func TestQuerier_GetAppserverSubById(t *testing.T) {
 	})
 
 	t.Run("Error:sub_does_not_exist", func(t *testing.T) {
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		_, err := qx.New(testutil.TestDbConn).GetAppserverSubById(ctx, uuid.New())
 		assert.Error(t, err)
 	})
 }
 
 func TestQuerier_ListAppserverUserSubs(t *testing.T) {
-	t.Run("Successlist_appserver_user_subs", func(t *testing.T) {
-		ctx := testutil.Setup(t, func() {})
-		su := factory.UserAppserverSub(t)
+	t.Run("Success:list_appserver_user_subs", func(t *testing.T) {
+		ctx, db := testutil.Setup(t, func() {})
+		su := factory.UserAppserverSub(t, ctx, db)
 		sub2 := testutil.TestAppserverSub(t, nil, false)
 
 		results, err := qx.New(testutil.TestDbConn).ListAppserverUserSubs(ctx, su.Server.ID)
@@ -144,9 +144,9 @@ func TestQuerier_ListAppserverUserSubs(t *testing.T) {
 }
 
 func TestQuerier_ListUserServerSubs(t *testing.T) {
-	t.Run("Successlist_user_server_subs", func(t *testing.T) {
-		ctx := testutil.Setup(t, func() {})
-		su := factory.UserAppserverSub(t)
+	t.Run("Success:list_user_server_subs", func(t *testing.T) {
+		ctx, db := testutil.Setup(t, func() {})
+		su := factory.UserAppserverSub(t, ctx, db)
 		sub2 := testutil.TestAppserverSub(t, nil, false)
 
 		results, err := qx.New(testutil.TestDbConn).ListUserServerSubs(ctx, su.User.ID)

--- a/src/psql_db/qx/appserver_test.go
+++ b/src/psql_db/qx/appserver_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func TestQuerier_CreateAppserver(t *testing.T) {
-	t.Run("Successcreate_appserver", func(t *testing.T) {
+	t.Run("Success:create_appserver", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		user := testutil.TestAppuser(t, nil, false)
 
 		params := qx.CreateAppserverParams{
@@ -34,9 +34,9 @@ func TestQuerier_CreateAppserver(t *testing.T) {
 }
 
 func TestQuerier_GetAppserverById(t *testing.T) {
-	t.Run("Successget_appserver_by_id", func(t *testing.T) {
+	t.Run("Success:get_appserver_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		server := testutil.TestAppserver(t, nil, false)
 
 		// ACT
@@ -49,7 +49,7 @@ func TestQuerier_GetAppserverById(t *testing.T) {
 
 	t.Run("Error:appserver_does_not_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 
 		// ACT
 		_, err := qx.New(testutil.TestDbConn).GetAppserverById(ctx, uuid.New())
@@ -61,9 +61,9 @@ func TestQuerier_GetAppserverById(t *testing.T) {
 }
 
 func TestQuerier_DeleteAppserver(t *testing.T) {
-	t.Run("Successdelete_appserver", func(t *testing.T) {
+	t.Run("Success:delete_appserver", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		server := testutil.TestAppserver(t, nil, false)
 
 		// ACT
@@ -76,7 +76,7 @@ func TestQuerier_DeleteAppserver(t *testing.T) {
 
 	t.Run("Error:appserver_does_not_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 
 		// ACT
 		count, err := qx.New(testutil.TestDbConn).DeleteAppserver(ctx, uuid.New())
@@ -86,10 +86,10 @@ func TestQuerier_DeleteAppserver(t *testing.T) {
 		assert.Equal(t, int64(0), count)
 	})
 
-	t.Run("Successdeletes_all_relationships", func(t *testing.T) {
+	t.Run("Success:deletes_all_relationships", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
-		tu := factory.UserAppserverSub(t)
+		ctx, db := testutil.Setup(t, func() {})
+		tu := factory.UserAppserverSub(t, ctx, db)
 		role := testutil.TestAppserverRole(t, &qx.AppserverRole{AppserverID: tu.Server.ID, Name: "foo"}, false)
 		roleSub := testutil.TestAppserverRoleSub(t, &qx.AppserverRoleSub{
 			AppuserID:       tu.User.ID,
@@ -151,9 +151,9 @@ func TestQuerier_DeleteAppserver(t *testing.T) {
 }
 
 func TestQuerier_ListAppservers(t *testing.T) {
-	t.Run("Successlist_appservers_by_user", func(t *testing.T) {
+	t.Run("Success:list_appservers_by_user", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		server := testutil.TestAppserver(t, nil, false)
 
 		params := qx.ListAppserversParams{
@@ -169,9 +169,9 @@ func TestQuerier_ListAppservers(t *testing.T) {
 		assert.NotEmpty(t, results)
 	})
 
-	t.Run("Successlist_appservers_by_user_and_name", func(t *testing.T) {
+	t.Run("Success:list_appservers_by_user_and_name", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		server := testutil.TestAppserver(t, nil, false)
 
 		params := qx.ListAppserversParams{
@@ -188,9 +188,9 @@ func TestQuerier_ListAppservers(t *testing.T) {
 		assert.Equal(t, server.ID, results[0].ID)
 	})
 
-	t.Run("Successlist_appservers_no_results", func(t *testing.T) {
+	t.Run("Success:list_appservers_no_results", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 
 		params := qx.ListAppserversParams{
 			AppuserID: uuid.New(),

--- a/src/psql_db/qx/appserver_test.go
+++ b/src/psql_db/qx/appserver_test.go
@@ -15,16 +15,16 @@ import (
 func TestQuerier_CreateAppserver(t *testing.T) {
 	t.Run("Success:create_appserver", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		user := testutil.TestAppuser(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		u := factory.NewFactory(ctx, db).Appuser(t, 0, nil)
 
 		params := qx.CreateAppserverParams{
 			Name:      "Test Server",
-			AppuserID: user.ID,
+			AppuserID: u.ID,
 		}
 
 		// ACT
-		server, err := qx.New(testutil.TestDbConn).CreateAppserver(ctx, params)
+		server, err := db.CreateAppserver(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -36,11 +36,11 @@ func TestQuerier_CreateAppserver(t *testing.T) {
 func TestQuerier_GetAppserverById(t *testing.T) {
 	t.Run("Success:get_appserver_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		server := testutil.TestAppserver(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		server := factory.NewFactory(ctx, db).Appserver(t, 0, nil)
 
 		// ACT
-		result, err := qx.New(testutil.TestDbConn).GetAppserverById(ctx, server.ID)
+		result, err := db.GetAppserverById(ctx, server.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -49,10 +49,10 @@ func TestQuerier_GetAppserverById(t *testing.T) {
 
 	t.Run("Error:appserver_does_not_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 
 		// ACT
-		_, err := qx.New(testutil.TestDbConn).GetAppserverById(ctx, uuid.New())
+		_, err := db.GetAppserverById(ctx, uuid.New())
 
 		// ASSERT
 		assert.Error(t, err)
@@ -63,11 +63,11 @@ func TestQuerier_GetAppserverById(t *testing.T) {
 func TestQuerier_DeleteAppserver(t *testing.T) {
 	t.Run("Success:delete_appserver", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		server := testutil.TestAppserver(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		server := factory.NewFactory(ctx, db).Appserver(t, 0, nil)
 
 		// ACT
-		count, err := qx.New(testutil.TestDbConn).DeleteAppserver(ctx, server.ID)
+		count, err := db.DeleteAppserver(ctx, server.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -76,10 +76,10 @@ func TestQuerier_DeleteAppserver(t *testing.T) {
 
 	t.Run("Error:appserver_does_not_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 
 		// ACT
-		count, err := qx.New(testutil.TestDbConn).DeleteAppserver(ctx, uuid.New())
+		count, err := db.DeleteAppserver(ctx, uuid.New())
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -89,35 +89,22 @@ func TestQuerier_DeleteAppserver(t *testing.T) {
 	t.Run("Success:deletes_all_relationships", func(t *testing.T) {
 		// ARRANGE
 		ctx, db := testutil.Setup(t, func() {})
-		tu := factory.UserAppserverSub(t, ctx, db)
-		role := testutil.TestAppserverRole(t, &qx.AppserverRole{AppserverID: tu.Server.ID, Name: "foo"}, false)
-		roleSub := testutil.TestAppserverRoleSub(t, &qx.AppserverRoleSub{
-			AppuserID:       tu.User.ID,
-			AppserverID:     tu.Server.ID,
-			AppserverRoleID: role.ID,
-			AppserverSubID:  tu.Sub.ID,
-		}, false)
-
-		channel := testutil.TestChannel(t, &qx.Channel{
-			Name:        "general",
-			AppserverID: tu.Server.ID,
-			IsPrivate:   false,
-		}, false)
-
-		channelRole := testutil.TestChannelRole(t, &qx.ChannelRole{
-			ChannelID:       channel.ID,
-			AppserverRoleID: role.ID,
-			AppserverID:     tu.Server.ID,
-		}, false)
+		f := factory.NewFactory(ctx, db)
+		server := f.Appserver(t, 0, nil)
+		sub := f.AppserverSub(t, 0, nil)
+		role := f.AppserverRole(t, 0, nil)
+		roleSub := f.AppserverRoleSub(t, 0, nil)
+		channel := f.Channel(t, 0, nil)
+		channelRole := f.ChannelRole(t, 0, nil)
 
 		// ACT
-		count, err := qx.New(testutil.TestDbConn).DeleteAppserver(ctx, tu.Server.ID)
+		count, err := db.DeleteAppserver(ctx, server.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), count)
 
-		q := qx.New(testutil.TestDbConn)
+		q := db
 		// Verify that the AppserverRoleSub is deleted
 		_, err = q.GetAppserverRoleSubById(ctx, roleSub.ID)
 		assert.Error(t, err)
@@ -139,12 +126,12 @@ func TestQuerier_DeleteAppserver(t *testing.T) {
 		assert.Contains(t, err.Error(), "no rows in result set")
 
 		// Verify that the Appserver is deleted
-		_, err = q.GetAppserverById(ctx, tu.Server.ID)
+		_, err = q.GetAppserverById(ctx, server.ID)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no rows in result set")
 
 		// Verify that the AppserverSub is deleted
-		_, err = q.GetAppserverSubById(ctx, tu.Sub.ID)
+		_, err = q.GetAppserverSubById(ctx, sub.ID)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no rows in result set")
 	})
@@ -153,8 +140,8 @@ func TestQuerier_DeleteAppserver(t *testing.T) {
 func TestQuerier_ListAppservers(t *testing.T) {
 	t.Run("Success:list_appservers_by_user", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		server := testutil.TestAppserver(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		server := factory.NewFactory(ctx, db).Appserver(t, 0, nil)
 
 		params := qx.ListAppserversParams{
 			AppuserID: server.AppuserID,
@@ -162,7 +149,7 @@ func TestQuerier_ListAppservers(t *testing.T) {
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).ListAppservers(ctx, params)
+		results, err := db.ListAppservers(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -171,8 +158,8 @@ func TestQuerier_ListAppservers(t *testing.T) {
 
 	t.Run("Success:list_appservers_by_user_and_name", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		server := testutil.TestAppserver(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		server := factory.NewFactory(ctx, db).Appserver(t, 0, nil)
 
 		params := qx.ListAppserversParams{
 			AppuserID: server.AppuserID,
@@ -180,7 +167,7 @@ func TestQuerier_ListAppservers(t *testing.T) {
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).ListAppservers(ctx, params)
+		results, err := db.ListAppservers(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -190,7 +177,7 @@ func TestQuerier_ListAppservers(t *testing.T) {
 
 	t.Run("Success:list_appservers_no_results", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 
 		params := qx.ListAppserversParams{
 			AppuserID: uuid.New(),
@@ -198,7 +185,7 @@ func TestQuerier_ListAppservers(t *testing.T) {
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).ListAppservers(ctx, params)
+		results, err := db.ListAppservers(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)

--- a/src/psql_db/qx/appuser_test.go
+++ b/src/psql_db/qx/appuser_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func TestQuerier_CreateAppuser(t *testing.T) {
-	t.Run("Successcreate_appuser", func(t *testing.T) {
+	t.Run("Success:create_appuser", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		id := uuid.New()
 		username := "testuser"
 
@@ -33,9 +33,9 @@ func TestQuerier_CreateAppuser(t *testing.T) {
 }
 
 func TestQuerier_GetAppuserById(t *testing.T) {
-	t.Run("Successget_appuser_by_id", func(t *testing.T) {
+	t.Run("Success:get_appuser_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		id := uuid.New()
 		username := "retrievable_user"
 		_, err := qx.New(testutil.TestDbConn).CreateAppuser(ctx, qx.CreateAppuserParams{
@@ -55,7 +55,7 @@ func TestQuerier_GetAppuserById(t *testing.T) {
 
 	t.Run("Error:get_nonexistent_appuser", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		nonexistentID := uuid.New()
 
 		// ACT

--- a/src/psql_db/qx/appuser_test.go
+++ b/src/psql_db/qx/appuser_test.go
@@ -8,12 +8,13 @@ import (
 
 	"mist/src/psql_db/qx"
 	"mist/src/testutil"
+	"mist/src/testutil/factory"
 )
 
 func TestQuerier_CreateAppuser(t *testing.T) {
 	t.Run("Success:create_appuser", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		id := uuid.New()
 		username := "testuser"
 
@@ -23,7 +24,7 @@ func TestQuerier_CreateAppuser(t *testing.T) {
 		}
 
 		// ACT
-		user, err := qx.New(testutil.TestDbConn).CreateAppuser(ctx, params)
+		user, err := db.CreateAppuser(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -35,31 +36,25 @@ func TestQuerier_CreateAppuser(t *testing.T) {
 func TestQuerier_GetAppuserById(t *testing.T) {
 	t.Run("Success:get_appuser_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		id := uuid.New()
-		username := "retrievable_user"
-		_, err := qx.New(testutil.TestDbConn).CreateAppuser(ctx, qx.CreateAppuserParams{
-			ID:       id,
-			Username: username,
-		})
-		assert.NoError(t, err)
+		ctx, db := testutil.Setup(t, func() {})
+		u := factory.NewFactory(ctx, db).Appuser(t, 0, nil)
 
 		// ACT
-		user, err := qx.New(testutil.TestDbConn).GetAppuserById(ctx, id)
+		user, err := db.GetAppuserById(ctx, u.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
-		assert.Equal(t, id, user.ID)
-		assert.Equal(t, username, user.Username)
+		assert.Equal(t, user.ID, user.ID)
+		assert.Equal(t, user.Username, user.Username)
 	})
 
 	t.Run("Error:get_nonexistent_appuser", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		nonexistentID := uuid.New()
 
 		// ACT
-		_, err := qx.New(testutil.TestDbConn).GetAppuserById(ctx, nonexistentID)
+		_, err := db.GetAppuserById(ctx, nonexistentID)
 
 		// ASSERT
 		assert.Error(t, err)

--- a/src/psql_db/qx/channel_role_test.go
+++ b/src/psql_db/qx/channel_role_test.go
@@ -117,7 +117,7 @@ func TestQuerier_FilterChannelRole(t *testing.T) {
 	t.Run("Success:filter_by_partial_fields", func(t *testing.T) {
 		// ARRANGE
 		ctx, db := testutil.Setup(t, func() {})
-		cr := testutil.TestChannelRole(t, nil, false)
+		cr := factory.NewFactory(ctx, db).ChannelRole(t, 0, nil)
 
 		params := qx.FilterChannelRoleParams{
 			ChannelID:       pgtype.UUID{Bytes: cr.ChannelID, Valid: true},
@@ -156,7 +156,7 @@ func TestQuerier_ListChannelRoles(t *testing.T) {
 	t.Run("Success:list_channel_roles", func(t *testing.T) {
 		// ARRANGE
 		ctx, db := testutil.Setup(t, func() {})
-		cr := testutil.TestChannelRole(t, nil, false)
+		cr := factory.NewFactory(ctx, db).ChannelRole(t, 0, nil)
 
 		// ACT
 		results, err := db.ListChannelRoles(ctx, cr.ChannelID)

--- a/src/psql_db/qx/channel_role_test.go
+++ b/src/psql_db/qx/channel_role_test.go
@@ -9,14 +9,16 @@ import (
 
 	"mist/src/psql_db/qx"
 	"mist/src/testutil"
+	"mist/src/testutil/factory"
 )
 
 func TestQuerier_CreateChannelRole(t *testing.T) {
 	t.Run("Success:create_channel_role", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		ch := testutil.TestChannel(t, nil, false)
-		role := testutil.TestAppserverRole(t, &qx.AppserverRole{AppserverID: ch.AppserverID}, false)
+		ctx, db := testutil.Setup(t, func() {})
+		f := factory.NewFactory(ctx, db)
+		role := f.AppserverRole(t, 0, nil)
+		ch := f.Channel(t, 0, nil)
 
 		params := qx.CreateChannelRoleParams{
 			ChannelID:       ch.ID,
@@ -25,7 +27,7 @@ func TestQuerier_CreateChannelRole(t *testing.T) {
 		}
 
 		// ACT
-		cr, err := qx.New(testutil.TestDbConn).CreateChannelRole(ctx, params)
+		cr, err := db.CreateChannelRole(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -38,15 +40,11 @@ func TestQuerier_CreateChannelRole(t *testing.T) {
 func TestQuerier_DeleteChannelRole(t *testing.T) {
 	t.Run("Success:delete_channel_role", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		ch := testutil.TestChannel(t, nil, false)
-		role := testutil.TestAppserverRole(t, &qx.AppserverRole{AppserverID: ch.AppserverID}, false)
-		cr := testutil.TestChannelRole(t, &qx.ChannelRole{
-			ChannelID: ch.ID, AppserverRoleID: role.ID, AppserverID: ch.AppserverID,
-		}, false)
+		ctx, db := testutil.Setup(t, func() {})
+		cr := factory.NewFactory(ctx, db).ChannelRole(t, 0, nil)
 
 		// ACT
-		count, err := qx.New(testutil.TestDbConn).DeleteChannelRole(ctx, cr.ID)
+		count, err := db.DeleteChannelRole(ctx, cr.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -55,11 +53,11 @@ func TestQuerier_DeleteChannelRole(t *testing.T) {
 
 	t.Run("Error:delete_nonexistent_channel_role", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		id := uuid.New()
 
 		// ACT
-		count, err := qx.New(testutil.TestDbConn).DeleteChannelRole(ctx, id)
+		count, err := db.DeleteChannelRole(ctx, id)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -70,11 +68,11 @@ func TestQuerier_DeleteChannelRole(t *testing.T) {
 func TestQuerier_GetChannelRoleById(t *testing.T) {
 	t.Run("Success:get_channel_role_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		chRole := testutil.TestChannelRole(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		chRole := factory.NewFactory(ctx, db).ChannelRole(t, 0, nil)
 
 		// ACT
-		found, err := qx.New(testutil.TestDbConn).GetChannelRoleById(ctx, chRole.ID)
+		found, err := db.GetChannelRoleById(ctx, chRole.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -83,11 +81,11 @@ func TestQuerier_GetChannelRoleById(t *testing.T) {
 
 	t.Run("Error:get_channel_role_by_id_not_found", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		id := uuid.New()
 
 		// ACT
-		_, err := qx.New(testutil.TestDbConn).GetChannelRoleById(ctx, id)
+		_, err := db.GetChannelRoleById(ctx, id)
 
 		// ASSERT
 		assert.Error(t, err)
@@ -98,8 +96,8 @@ func TestQuerier_GetChannelRoleById(t *testing.T) {
 func TestQuerier_FilterChannelRole(t *testing.T) {
 	t.Run("Success:filter_by_all_fields", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		cr := testutil.TestChannelRole(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		cr := factory.NewFactory(ctx, db).ChannelRole(t, 0, nil)
 
 		params := qx.FilterChannelRoleParams{
 			ChannelID:       pgtype.UUID{Bytes: cr.ChannelID, Valid: true},
@@ -108,7 +106,7 @@ func TestQuerier_FilterChannelRole(t *testing.T) {
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).FilterChannelRole(ctx, params)
+		results, err := db.FilterChannelRole(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -118,7 +116,7 @@ func TestQuerier_FilterChannelRole(t *testing.T) {
 
 	t.Run("Success:filter_by_partial_fields", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		cr := testutil.TestChannelRole(t, nil, false)
 
 		params := qx.FilterChannelRoleParams{
@@ -128,7 +126,7 @@ func TestQuerier_FilterChannelRole(t *testing.T) {
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).FilterChannelRole(ctx, params)
+		results, err := db.FilterChannelRole(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -137,7 +135,7 @@ func TestQuerier_FilterChannelRole(t *testing.T) {
 
 	t.Run("EmptyResult:no_match_found", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 
 		params := qx.FilterChannelRoleParams{
 			ChannelID:       pgtype.UUID{Bytes: uuid.New(), Valid: true},
@@ -146,7 +144,7 @@ func TestQuerier_FilterChannelRole(t *testing.T) {
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).FilterChannelRole(ctx, params)
+		results, err := db.FilterChannelRole(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -157,11 +155,11 @@ func TestQuerier_FilterChannelRole(t *testing.T) {
 func TestQuerier_ListChannelRoles(t *testing.T) {
 	t.Run("Success:list_channel_roles", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		cr := testutil.TestChannelRole(t, nil, false)
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).ListChannelRoles(ctx, cr.ChannelID)
+		results, err := db.ListChannelRoles(ctx, cr.ChannelID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -171,11 +169,11 @@ func TestQuerier_ListChannelRoles(t *testing.T) {
 
 	t.Run("EmptyResult:list_channel_roles_empty", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		randomChannelID := uuid.New()
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).ListChannelRoles(ctx, randomChannelID)
+		results, err := db.ListChannelRoles(ctx, randomChannelID)
 
 		// ASSERT
 		assert.NoError(t, err)

--- a/src/psql_db/qx/channel_role_test.go
+++ b/src/psql_db/qx/channel_role_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestQuerier_CreateChannelRole(t *testing.T) {
-	t.Run("Successcreate_channel_role", func(t *testing.T) {
+	t.Run("Success:create_channel_role", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		ch := testutil.TestChannel(t, nil, false)
 		role := testutil.TestAppserverRole(t, &qx.AppserverRole{AppserverID: ch.AppserverID}, false)
 
@@ -36,9 +36,9 @@ func TestQuerier_CreateChannelRole(t *testing.T) {
 }
 
 func TestQuerier_DeleteChannelRole(t *testing.T) {
-	t.Run("Successdelete_channel_role", func(t *testing.T) {
+	t.Run("Success:delete_channel_role", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		ch := testutil.TestChannel(t, nil, false)
 		role := testutil.TestAppserverRole(t, &qx.AppserverRole{AppserverID: ch.AppserverID}, false)
 		cr := testutil.TestChannelRole(t, &qx.ChannelRole{
@@ -55,7 +55,7 @@ func TestQuerier_DeleteChannelRole(t *testing.T) {
 
 	t.Run("Error:delete_nonexistent_channel_role", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		id := uuid.New()
 
 		// ACT
@@ -68,9 +68,9 @@ func TestQuerier_DeleteChannelRole(t *testing.T) {
 }
 
 func TestQuerier_GetChannelRoleById(t *testing.T) {
-	t.Run("Successget_channel_role_by_id", func(t *testing.T) {
+	t.Run("Success:get_channel_role_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		chRole := testutil.TestChannelRole(t, nil, false)
 
 		// ACT
@@ -83,7 +83,7 @@ func TestQuerier_GetChannelRoleById(t *testing.T) {
 
 	t.Run("Error:get_channel_role_by_id_not_found", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		id := uuid.New()
 
 		// ACT
@@ -96,9 +96,9 @@ func TestQuerier_GetChannelRoleById(t *testing.T) {
 }
 
 func TestQuerier_FilterChannelRole(t *testing.T) {
-	t.Run("Successfilter_by_all_fields", func(t *testing.T) {
+	t.Run("Success:filter_by_all_fields", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		cr := testutil.TestChannelRole(t, nil, false)
 
 		params := qx.FilterChannelRoleParams{
@@ -116,9 +116,9 @@ func TestQuerier_FilterChannelRole(t *testing.T) {
 		assert.Equal(t, cr.ID, results[0].ID)
 	})
 
-	t.Run("Successfilter_by_partial_fields", func(t *testing.T) {
+	t.Run("Success:filter_by_partial_fields", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		cr := testutil.TestChannelRole(t, nil, false)
 
 		params := qx.FilterChannelRoleParams{
@@ -137,7 +137,7 @@ func TestQuerier_FilterChannelRole(t *testing.T) {
 
 	t.Run("EmptyResult:no_match_found", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 
 		params := qx.FilterChannelRoleParams{
 			ChannelID:       pgtype.UUID{Bytes: uuid.New(), Valid: true},
@@ -155,9 +155,9 @@ func TestQuerier_FilterChannelRole(t *testing.T) {
 }
 
 func TestQuerier_ListChannelRoles(t *testing.T) {
-	t.Run("Successlist_channel_roles", func(t *testing.T) {
+	t.Run("Success:list_channel_roles", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		cr := testutil.TestChannelRole(t, nil, false)
 
 		// ACT
@@ -171,7 +171,7 @@ func TestQuerier_ListChannelRoles(t *testing.T) {
 
 	t.Run("EmptyResult:list_channel_roles_empty", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		randomChannelID := uuid.New()
 
 		// ACT

--- a/src/psql_db/qx/channel_test.go
+++ b/src/psql_db/qx/channel_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func TestQuerier_CreateChannel(t *testing.T) {
-	t.Run("Successcreate_channel", func(t *testing.T) {
+	t.Run("Success:create_channel", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		server := testutil.TestAppserver(t, nil, false)
 
 		params := qx.CreateChannelParams{
@@ -35,9 +35,9 @@ func TestQuerier_CreateChannel(t *testing.T) {
 }
 
 func TestQuerier_GetChannelById(t *testing.T) {
-	t.Run("Successget_channel_by_id", func(t *testing.T) {
+	t.Run("Success:get_channel_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		ch := testutil.TestChannel(t, nil, false)
 
 		// ACT
@@ -50,7 +50,7 @@ func TestQuerier_GetChannelById(t *testing.T) {
 
 	t.Run("Error:channel_does_not_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		// ACT
 		_, err := qx.New(testutil.TestDbConn).GetChannelById(ctx, uuid.New())
 
@@ -61,9 +61,9 @@ func TestQuerier_GetChannelById(t *testing.T) {
 }
 
 func TestQuerier_DeleteChannel(t *testing.T) {
-	t.Run("Successdelete_channel", func(t *testing.T) {
+	t.Run("Success:delete_channel", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		ch := testutil.TestChannel(t, nil, false)
 
 		// ACT
@@ -74,9 +74,9 @@ func TestQuerier_DeleteChannel(t *testing.T) {
 		assert.Equal(t, int64(1), count)
 	})
 
-	t.Run("Successwhen_channel_is_deleted_it_removes_associated_channel_roles", func(t *testing.T) {
+	t.Run("Success:when_channel_is_deleted_it_removes_associated_channel_roles", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		ch := testutil.TestChannel(t, nil, false)
 		role := testutil.TestAppserverRole(t, &qx.AppserverRole{AppserverID: ch.AppserverID}, false)
 		channelRole := testutil.TestChannelRole(
@@ -98,7 +98,7 @@ func TestQuerier_DeleteChannel(t *testing.T) {
 
 	t.Run("Error:channel_does_not_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		// ACT
 		count, err := qx.New(testutil.TestDbConn).DeleteChannel(ctx, uuid.New())
 
@@ -109,9 +109,9 @@ func TestQuerier_DeleteChannel(t *testing.T) {
 }
 
 func TestQuerier_FilterChannel(t *testing.T) {
-	t.Run("Successfilter_channel", func(t *testing.T) {
+	t.Run("Success:filter_channel", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		ch := testutil.TestChannel(t, nil, false)
 
 		params := qx.FilterChannelParams{
@@ -129,7 +129,7 @@ func TestQuerier_FilterChannel(t *testing.T) {
 
 	t.Run("Error:filter_channel_no_results", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		testutil.TestChannel(t, nil, false)
 
 		params := qx.FilterChannelParams{
@@ -147,7 +147,7 @@ func TestQuerier_FilterChannel(t *testing.T) {
 
 	t.Run("Error:filter_channel_invalid_params", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		params := qx.FilterChannelParams{
 			AppserverID: pgtype.UUID{Valid: false},
 			IsPrivate:   pgtype.Bool{Valid: false},
@@ -163,9 +163,9 @@ func TestQuerier_FilterChannel(t *testing.T) {
 }
 
 func TestQuerier_GetChannelsIdIn(t *testing.T) {
-	t.Run("Successget_channels_id_in", func(t *testing.T) {
+	t.Run("Success:get_channels_id_in", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		ch := testutil.TestChannel(t, nil, false)
 		ch2 := testutil.TestChannel(t, nil, false)
 
@@ -181,7 +181,7 @@ func TestQuerier_GetChannelsIdIn(t *testing.T) {
 
 	t.Run("Error:get_channels_id_in_no_results", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		// ACT
 		results, err := qx.New(testutil.TestDbConn).GetChannelsIdIn(ctx, []uuid.UUID{uuid.New(), uuid.New()})
 
@@ -192,9 +192,9 @@ func TestQuerier_GetChannelsIdIn(t *testing.T) {
 }
 
 func TestQuerier_ListServerChannels(t *testing.T) {
-	t.Run("Successlist_server_channels", func(t *testing.T) {
+	t.Run("Success:list_server_channels", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		ch := testutil.TestChannel(t, nil, false)
 
 		params := qx.ListServerChannelsParams{
@@ -212,7 +212,7 @@ func TestQuerier_ListServerChannels(t *testing.T) {
 
 	t.Run("Error:list_server_channels_no_results", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		testutil.TestChannel(t, nil, false)
 
 		params := qx.ListServerChannelsParams{
@@ -230,10 +230,10 @@ func TestQuerier_ListServerChannels(t *testing.T) {
 }
 
 func TestQuerier_GetChannelsForUsers(t *testing.T) {
-	t.Run("Successget_channels_for_users", func(t *testing.T) {
+	t.Run("Success:get_channels_for_users", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
-		su := factory.UserAppserverSub(t)
+		ctx, db := testutil.Setup(t, func() {})
+		su := factory.UserAppserverSub(t, ctx, db)
 		user2 := testutil.TestAppuser(t, nil, false)
 		channel1 := testutil.TestChannel(t, &qx.Channel{Name: "c1", AppserverID: su.Server.ID, IsPrivate: true}, false)
 		_ = testutil.TestChannel(t, &qx.Channel{Name: "c2", AppserverID: su.Server.ID, IsPrivate: false}, false)

--- a/src/psql_db/qx/channel_test.go
+++ b/src/psql_db/qx/channel_test.go
@@ -15,8 +15,8 @@ import (
 func TestQuerier_CreateChannel(t *testing.T) {
 	t.Run("Success:create_channel", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		server := testutil.TestAppserver(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		server := factory.NewFactory(ctx, db).Appserver(t, 0, nil)
 
 		params := qx.CreateChannelParams{
 			Name:        "general",
@@ -25,7 +25,7 @@ func TestQuerier_CreateChannel(t *testing.T) {
 		}
 
 		// ACT
-		ch, err := qx.New(testutil.TestDbConn).CreateChannel(ctx, params)
+		ch, err := db.CreateChannel(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -37,11 +37,11 @@ func TestQuerier_CreateChannel(t *testing.T) {
 func TestQuerier_GetChannelById(t *testing.T) {
 	t.Run("Success:get_channel_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		ch := testutil.TestChannel(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		ch := factory.NewFactory(ctx, db).Channel(t, 0, nil)
 
 		// ACT
-		result, err := qx.New(testutil.TestDbConn).GetChannelById(ctx, ch.ID)
+		result, err := db.GetChannelById(ctx, ch.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -50,9 +50,11 @@ func TestQuerier_GetChannelById(t *testing.T) {
 
 	t.Run("Error:channel_does_not_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+
+		ctx, db := testutil.Setup(t, func() {})
+
 		// ACT
-		_, err := qx.New(testutil.TestDbConn).GetChannelById(ctx, uuid.New())
+		_, err := db.GetChannelById(ctx, uuid.New())
 
 		// ASSERT
 		assert.Error(t, err)
@@ -63,11 +65,11 @@ func TestQuerier_GetChannelById(t *testing.T) {
 func TestQuerier_DeleteChannel(t *testing.T) {
 	t.Run("Success:delete_channel", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		ch := testutil.TestChannel(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		ch := factory.NewFactory(ctx, db).Channel(t, 0, nil)
 
 		// ACT
-		count, err := qx.New(testutil.TestDbConn).DeleteChannel(ctx, ch.ID)
+		count, err := db.DeleteChannel(ctx, ch.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -76,31 +78,29 @@ func TestQuerier_DeleteChannel(t *testing.T) {
 
 	t.Run("Success:when_channel_is_deleted_it_removes_associated_channel_roles", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		ch := testutil.TestChannel(t, nil, false)
-		role := testutil.TestAppserverRole(t, &qx.AppserverRole{AppserverID: ch.AppserverID}, false)
-		channelRole := testutil.TestChannelRole(
-			t, &qx.ChannelRole{
-				ChannelID: ch.ID, AppserverRoleID: role.ID, AppserverID: ch.AppserverID,
-			}, false)
+		ctx, db := testutil.Setup(t, func() {})
+		f := factory.NewFactory(ctx, db)
+		ch := f.Channel(t, 0, nil)
+		f.AppserverRole(t, 0, nil)
+		channelRole := f.ChannelRole(t, 0, nil)
 
 		// ACT
-		count, err := qx.New(testutil.TestDbConn).DeleteChannel(ctx, ch.ID)
+		count, err := db.DeleteChannel(ctx, ch.ID)
 
 		// ASSERT
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), count)
 		// Verify that the channel role is also deleted
-		_, err = qx.New(testutil.TestDbConn).GetChannelRoleById(ctx, channelRole.ID)
+		_, err = db.GetChannelRoleById(ctx, channelRole.ID)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no rows in result set")
 	})
 
 	t.Run("Error:channel_does_not_exist", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		// ACT
-		count, err := qx.New(testutil.TestDbConn).DeleteChannel(ctx, uuid.New())
+		count, err := db.DeleteChannel(ctx, uuid.New())
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -111,8 +111,8 @@ func TestQuerier_DeleteChannel(t *testing.T) {
 func TestQuerier_FilterChannel(t *testing.T) {
 	t.Run("Success:filter_channel", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		ch := testutil.TestChannel(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		ch := factory.NewFactory(ctx, db).Channel(t, 0, nil)
 
 		params := qx.FilterChannelParams{
 			AppserverID: pgtype.UUID{Bytes: ch.AppserverID, Valid: true},
@@ -120,7 +120,7 @@ func TestQuerier_FilterChannel(t *testing.T) {
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).FilterChannel(ctx, params)
+		results, err := db.FilterChannel(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -129,8 +129,8 @@ func TestQuerier_FilterChannel(t *testing.T) {
 
 	t.Run("Error:filter_channel_no_results", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		testutil.TestChannel(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		factory.NewFactory(ctx, db).Channel(t, 0, nil)
 
 		params := qx.FilterChannelParams{
 			AppserverID: pgtype.UUID{Bytes: uuid.New(), Valid: true},
@@ -138,7 +138,7 @@ func TestQuerier_FilterChannel(t *testing.T) {
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).FilterChannel(ctx, params)
+		results, err := db.FilterChannel(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -147,14 +147,14 @@ func TestQuerier_FilterChannel(t *testing.T) {
 
 	t.Run("Error:filter_channel_invalid_params", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
 		params := qx.FilterChannelParams{
 			AppserverID: pgtype.UUID{Valid: false},
 			IsPrivate:   pgtype.Bool{Valid: false},
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).FilterChannel(ctx, params)
+		results, err := db.FilterChannel(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -165,25 +165,28 @@ func TestQuerier_FilterChannel(t *testing.T) {
 func TestQuerier_GetChannelsIdIn(t *testing.T) {
 	t.Run("Success:get_channels_id_in", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		ch := testutil.TestChannel(t, nil, false)
-		ch2 := testutil.TestChannel(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		f := factory.NewFactory(ctx, db)
+		ch1 := f.Channel(t, 0, nil)
+		ch2 := f.Channel(t, 1, nil)
+		f.Channel(t, 2, nil)
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).GetChannelsIdIn(ctx, []uuid.UUID{ch.ID, ch2.ID})
+		results, err := db.GetChannelsIdIn(ctx, []uuid.UUID{ch1.ID, ch2.ID})
 
 		// ASSERT
 		assert.NoError(t, err)
 		assert.Len(t, results, 2)
-		assert.Equal(t, ch.ID, results[0].ID)
+		assert.Equal(t, ch1.ID, results[0].ID)
 		assert.Equal(t, ch2.ID, results[1].ID)
 	})
 
 	t.Run("Error:get_channels_id_in_no_results", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
+		ctx, db := testutil.Setup(t, func() {})
+
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).GetChannelsIdIn(ctx, []uuid.UUID{uuid.New(), uuid.New()})
+		results, err := db.GetChannelsIdIn(ctx, []uuid.UUID{uuid.New(), uuid.New()})
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -194,8 +197,8 @@ func TestQuerier_GetChannelsIdIn(t *testing.T) {
 func TestQuerier_ListServerChannels(t *testing.T) {
 	t.Run("Success:list_server_channels", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		ch := testutil.TestChannel(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		ch := factory.NewFactory(ctx, db).Channel(t, 0, nil)
 
 		params := qx.ListServerChannelsParams{
 			AppserverID: ch.AppserverID,
@@ -203,7 +206,7 @@ func TestQuerier_ListServerChannels(t *testing.T) {
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).ListServerChannels(ctx, params)
+		results, err := db.ListServerChannels(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -212,8 +215,9 @@ func TestQuerier_ListServerChannels(t *testing.T) {
 
 	t.Run("Error:list_server_channels_no_results", func(t *testing.T) {
 		// ARRANGE
-		ctx, _ := testutil.Setup(t, func() {})
-		testutil.TestChannel(t, nil, false)
+		ctx, db := testutil.Setup(t, func() {})
+		f := factory.NewFactory(ctx, db)
+		f.Channel(t, 0, nil)
 
 		params := qx.ListServerChannelsParams{
 			AppserverID: uuid.New(),
@@ -221,7 +225,7 @@ func TestQuerier_ListServerChannels(t *testing.T) {
 		}
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).ListServerChannels(ctx, params)
+		results, err := db.ListServerChannels(ctx, params)
 
 		// ASSERT
 		assert.NoError(t, err)
@@ -233,27 +237,23 @@ func TestQuerier_GetChannelsForUsers(t *testing.T) {
 	t.Run("Success:get_channels_for_users", func(t *testing.T) {
 		// ARRANGE
 		ctx, db := testutil.Setup(t, func() {})
-		su := factory.UserAppserverSub(t, ctx, db)
-		user2 := testutil.TestAppuser(t, nil, false)
-		channel1 := testutil.TestChannel(t, &qx.Channel{Name: "c1", AppserverID: su.Server.ID, IsPrivate: true}, false)
-		_ = testutil.TestChannel(t, &qx.Channel{Name: "c2", AppserverID: su.Server.ID, IsPrivate: false}, false)
-		role := testutil.TestAppserverRole(t, &qx.AppserverRole{AppserverID: su.Server.ID, Name: "test_role"}, false)
-		testutil.TestChannelRole(
-			t, &qx.ChannelRole{
-				ChannelID: channel1.ID, AppserverRoleID: role.ID, AppserverID: su.Server.ID,
-			}, false)
 
-		testutil.TestAppserverRoleSub(
-			t,
-			&qx.AppserverRoleSub{
-				AppuserID: su.User.ID, AppserverRoleID: role.ID, AppserverSubID: su.Sub.ID, AppserverID: su.Server.ID,
-			}, false,
-		)
+		f := factory.NewFactory(ctx, db)
+		server := f.Appserver(t, 0, nil)
+		f.Channel(t, 0, &qx.Channel{Name: "c1", AppserverID: server.ID, IsPrivate: true})
+		f.Channel(t, 1, &qx.Channel{Name: "c2", AppserverID: server.ID, IsPrivate: false})
+		f.AppserverRole(t, 0, nil)
+		user1 := f.Appuser(t, 0, nil)
+		user2 := f.Appuser(t, 1, nil)
+		f.AppserverSub(t, 0, nil)
+		f.AppserverSub(t, 1, &qx.AppserverSub{AppuserID: user2.ID, AppserverID: server.ID})
+		f.AppserverRoleSub(t, 0, nil)
+		f.ChannelRole(t, 0, nil)
 
 		// ACT
-		results, err := qx.New(testutil.TestDbConn).GetChannelsForUsers(ctx, qx.GetChannelsForUsersParams{
-			Column1:     []uuid.UUID{su.User.ID, user2.ID},
-			AppserverID: su.Server.ID,
+		results, err := db.GetChannelsForUsers(ctx, qx.GetChannelsForUsersParams{
+			Column1:     []uuid.UUID{user1.ID, user2.ID},
+			AppserverID: server.ID,
 		})
 
 		// ASSERT
@@ -266,9 +266,9 @@ func TestQuerier_GetChannelsForUsers(t *testing.T) {
 			users = append(users, r.AppuserID)
 			userChannels[r.AppuserID] = append(userChannels[r.AppuserID], r.ChannelID.Bytes)
 		}
-		assert.Contains(t, users, su.User.ID)
+		assert.Contains(t, users, user1.ID)
 		assert.Contains(t, users, user2.ID)
-		assert.Equal(t, 2, len(userChannels[su.User.ID]))
+		assert.Equal(t, 2, len(userChannels[user1.ID]))
 		assert.Equal(t, 1, len(userChannels[user2.ID]))
 	})
 }

--- a/src/psql_db/schema.sql
+++ b/src/psql_db/schema.sql
@@ -111,7 +111,7 @@ ALTER TABLE ONLY public.appserver_sub
     ADD CONSTRAINT appserver_sub_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY public.appserver_sub
-    ADD CONSTRAINT appserver_sub_uk_appserver_owner UNIQUE (appserver_id, appuser_id);
+    ADD CONSTRAINT appserver_sub_uk_appserver_user UNIQUE (appserver_id, appuser_id);
 
 ALTER TABLE ONLY public.appserver_sub
     ADD CONSTRAINT appserver_sub_uk_server_sub UNIQUE (appserver_id, id);

--- a/src/rpcs/appserver.go
+++ b/src/rpcs/appserver.go
@@ -2,6 +2,8 @@ package rpcs
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -10,6 +12,7 @@ import (
 	"mist/src/middleware"
 	"mist/src/permission"
 	"mist/src/protos/v1/appserver"
+	"mist/src/psql_db/db"
 	"mist/src/psql_db/qx"
 	"mist/src/service"
 )
@@ -18,7 +21,10 @@ func (s *AppserverGRPCService) Create(
 	ctx context.Context, req *appserver.CreateRequest,
 ) (*appserver.CreateResponse, error) {
 
-	var err error
+	var (
+		err error
+		db  db.Querier
+	)
 
 	if err = s.Auth.Authorize(ctx, nil, permission.ActionCreate); err != nil {
 		return nil, faults.RpcCustomErrorHandler(ctx, faults.ExtendError(err))
@@ -27,17 +33,36 @@ func (s *AppserverGRPCService) Create(
 	claims, _ := middleware.GetJWTClaims(ctx)
 	userId, _ := uuid.Parse(claims.UserID)
 
-	serverS := service.NewAppserverService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
-	)
-	aserver, err := serverS.Create(qx.CreateAppserverParams{Name: req.Name, AppuserID: userId})
+	db, err = s.Deps.Db.Begin(ctx)
 
 	if err != nil {
 		return nil, faults.RpcCustomErrorHandler(ctx, faults.ExtendError(err))
 	}
 
+	serverS := service.NewAppserverService(
+		ctx, &service.ServiceDeps{Db: db, MProducer: s.Deps.MProducer},
+	)
+
+	aserver, err := serverS.Create(qx.CreateAppserverParams{Name: req.Name, AppuserID: userId})
+
+	if err != nil {
+		if rollbackErr := db.Rollback(ctx); rollbackErr != nil {
+			return nil, faults.RpcCustomErrorHandler(
+				ctx, faults.DatabaseError(fmt.Sprintf("rollback error: %v | %v", rollbackErr, err.Error()), slog.LevelError),
+			)
+		}
+
+		return nil, faults.RpcCustomErrorHandler(ctx, faults.ExtendError(err))
+	}
+
 	res := serverS.PgTypeToPb(aserver)
 	res.IsOwner = aserver.AppuserID == userId
+
+	if err = db.Commit(ctx); err != nil {
+		return nil, faults.RpcCustomErrorHandler(
+			ctx, faults.DatabaseError(fmt.Sprintf("commit error: %v", err.Error()), slog.LevelError),
+		)
+	}
 
 	return &appserver.CreateResponse{Appserver: res}, nil
 }
@@ -58,7 +83,7 @@ func (s *AppserverGRPCService) GetById(
 	claims, _ := middleware.GetJWTClaims(ctx)
 
 	as := service.NewAppserverService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 	id, _ := uuid.Parse(req.Id)
 
@@ -84,7 +109,7 @@ func (s *AppserverGRPCService) List(
 	userId, _ := uuid.Parse(claims.UserID)
 
 	as := service.NewAppserverService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 	var name = pgtype.Text{Valid: false, String: ""}
 
@@ -123,7 +148,7 @@ func (s *AppserverGRPCService) Delete(
 
 	id, _ = uuid.Parse(req.Id)
 	err = service.NewAppserverService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	).Delete(id)
 
 	if err != nil {

--- a/src/rpcs/appserver_role.go
+++ b/src/rpcs/appserver_role.go
@@ -19,16 +19,14 @@ func (s *AppserverRoleGRPCService) Create(
 	var err error
 
 	serverId, _ := uuid.Parse(req.AppserverId)
-	ctx = context.WithValue(
-		ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId},
-	)
+	ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId})
 
 	if err = s.Auth.Authorize(ctx, nil, permission.ActionCreate); err != nil {
 		return nil, faults.RpcCustomErrorHandler(ctx, faults.ExtendError(err))
 	}
 
 	roleService := service.NewAppserverRoleService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 	aRole, err := roleService.Create(qx.CreateAppserverRoleParams{
 		Name: req.Name, AppserverID: serverId, AppserverPermissionMask: req.AppserverPermissionMask,
@@ -61,7 +59,7 @@ func (s *AppserverRoleGRPCService) ListServerRoles(
 	}
 
 	roleService := service.NewAppserverRoleService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 	results, err := roleService.ListAppserverRoles(serverId)
 
@@ -89,9 +87,7 @@ func (s *AppserverRoleGRPCService) Delete(
 	var err error
 
 	serverId, _ := uuid.Parse(req.AppserverId)
-	ctx = context.WithValue(
-		ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId},
-	)
+	ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId})
 
 	if err = s.Auth.Authorize(ctx, &req.Id, permission.ActionDelete); err != nil {
 		return nil, faults.RpcCustomErrorHandler(ctx, faults.ExtendError(err))
@@ -102,7 +98,7 @@ func (s *AppserverRoleGRPCService) Delete(
 
 	// Call delete service method
 	err = service.NewAppserverRoleService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	).Delete(roleId)
 
 	// Error handling

--- a/src/rpcs/appserver_role_sub.go
+++ b/src/rpcs/appserver_role_sub.go
@@ -19,16 +19,14 @@ func (s *AppserverRoleSubGRPCService) Create(
 	var err error
 
 	serverId, _ := uuid.Parse(req.AppserverId)
-	ctx = context.WithValue(
-		ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId},
-	)
+	ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId})
 
 	if err = s.Auth.Authorize(ctx, nil, permission.ActionCreate); err != nil {
 		return nil, faults.RpcCustomErrorHandler(ctx, faults.ExtendError(err))
 	}
 
 	roleSubS := service.NewAppserverRoleSubService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 
 	// TODO: Figure out what can go wrong to add error handler
@@ -71,7 +69,7 @@ func (s *AppserverRoleSubGRPCService) ListServerRoleSubs(
 	}
 
 	results, _ := service.NewAppserverRoleSubService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	).ListServerRoleSubs(serverId)
 
 	// Construct the response
@@ -99,9 +97,7 @@ func (s *AppserverRoleSubGRPCService) Delete(
 	var err error
 
 	serverId, _ := uuid.Parse(req.AppserverId)
-	ctx = context.WithValue(
-		ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId},
-	)
+	ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId})
 
 	if err = s.Auth.Authorize(ctx, &req.Id, permission.ActionDelete); err != nil {
 		return nil, faults.RpcCustomErrorHandler(ctx, faults.ExtendError(err))
@@ -109,7 +105,7 @@ func (s *AppserverRoleSubGRPCService) Delete(
 
 	// Initialize the service for AppserveRole
 	arss := service.NewAppserverRoleSubService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 	roleSubId, _ := uuid.Parse(req.Id)
 

--- a/src/rpcs/appserver_sub.go
+++ b/src/rpcs/appserver_sub.go
@@ -18,7 +18,7 @@ func (s *AppserverSubGRPCService) Create(
 ) (*appserver_sub.CreateResponse, error) {
 
 	subService := service.NewAppserverSubService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 	claims, _ := middleware.GetJWTClaims(ctx)
 
@@ -43,7 +43,7 @@ func (s *AppserverSubGRPCService) ListUserServerSubs(
 
 	// Initialize the service for AppserverSub
 	subService := service.NewAppserverSubService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 
 	claims, _ := middleware.GetJWTClaims(ctx)
@@ -85,7 +85,7 @@ func (s *AppserverSubGRPCService) ListAppserverUserSubs(
 
 	// Initialize the service for AppserverSub
 	subService := service.NewAppserverSubService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 	results, _ := subService.ListAppserverUserSubs(serverId)
 
@@ -109,9 +109,7 @@ func (s *AppserverSubGRPCService) Delete(
 	var err error
 
 	serverId, _ := uuid.Parse(req.AppserverId)
-	ctx = context.WithValue(
-		ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId},
-	)
+	ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId})
 
 	if err = s.Auth.Authorize(ctx, &req.Id, permission.ActionDelete); err != nil {
 		return nil, faults.RpcCustomErrorHandler(ctx, faults.ExtendError(err))
@@ -119,7 +117,7 @@ func (s *AppserverSubGRPCService) Delete(
 
 	id, _ := uuid.Parse((req.Id))
 	err = service.NewAppserverSubService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	).Delete(id)
 
 	// Error handling

--- a/src/rpcs/appserver_sub_test.go
+++ b/src/rpcs/appserver_sub_test.go
@@ -42,13 +42,14 @@ func TestAppserverSubRPCService_ListUserServerSubs(t *testing.T) {
 	t.Run("Success:can_return_all_users_appserver_subs_successfully", func(t *testing.T) {
 		// ARRANGE
 		ctx, db := testutil.Setup(t, func() {})
-		su := factory.UserAppserverUnsub(t, ctx, db)
 		f := factory.NewFactory(ctx, db)
-		s1 := f.Appserver(t, 2, nil)
-		s2 := f.Appserver(t, 3, nil)
+		parsedUid, err := uuid.Parse(ctx.Value(testutil.CtxUserKey).(string))
+		user := f.Appuser(t, 1, &qx.Appuser{ID: parsedUid, Username: "testuser"})
+		s1 := f.Appserver(t, 1, nil)
+		s2 := f.Appserver(t, 2, nil)
 
-		f.AppserverSub(t, 2, &qx.AppserverSub{AppserverID: s1.ID, AppuserID: su.User.ID})
-		f.AppserverSub(t, 3, &qx.AppserverSub{AppserverID: s2.ID, AppuserID: su.User.ID})
+		f.AppserverSub(t, 1, &qx.AppserverSub{AppserverID: s1.ID, AppuserID: user.ID})
+		f.AppserverSub(t, 2, &qx.AppserverSub{AppserverID: s2.ID, AppuserID: user.ID})
 
 		svc := &rpcs.AppserverSubGRPCService{Deps: &rpcs.GrpcDependencies{Db: db}, Auth: testutil.TestMockAuth}
 

--- a/src/rpcs/appuser.go
+++ b/src/rpcs/appuser.go
@@ -17,7 +17,7 @@ func (s *AppuserGRPCService) Create(
 
 	userId, _ := uuid.Parse(req.Id)
 	_, err := service.NewAppuserService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	).Create(
 		qx.CreateAppuserParams{
 			ID:       userId,

--- a/src/rpcs/base.go
+++ b/src/rpcs/base.go
@@ -3,7 +3,7 @@ package rpcs
 import (
 	"github.com/bufbuild/protovalidate-go"
 	protovalidate_middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/protovalidate"
-	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5"
 	"google.golang.org/grpc"
 
 	"mist/src/middleware"
@@ -21,7 +21,7 @@ import (
 
 type GrpcDependencies struct {
 	Db        db.Querier
-	DbConn    *pgxpool.Pool
+	DbTx      pgx.Tx
 	MProducer *producer.MProducer
 }
 
@@ -81,7 +81,7 @@ func RegisterGrpcServices(s *grpc.Server, deps *GrpcDependencies) {
 		s,
 		&AppserverGRPCService{
 			Deps: deps,
-			Auth: permission.NewAppserverAuthorizer(deps.DbConn, deps.Db),
+			Auth: permission.NewAppserverAuthorizer(deps.Db),
 		},
 	)
 
@@ -90,7 +90,7 @@ func RegisterGrpcServices(s *grpc.Server, deps *GrpcDependencies) {
 		s,
 		&AppserverRoleGRPCService{
 			Deps: deps,
-			Auth: permission.NewAppserverRoleAuthorizer(deps.DbConn, deps.Db),
+			Auth: permission.NewAppserverRoleAuthorizer(deps.Db),
 		},
 	)
 
@@ -99,7 +99,7 @@ func RegisterGrpcServices(s *grpc.Server, deps *GrpcDependencies) {
 		s,
 		&AppserverRoleSubGRPCService{
 			Deps: deps,
-			Auth: permission.NewAppserverRoleSubAuthorizer(deps.DbConn, deps.Db),
+			Auth: permission.NewAppserverRoleSubAuthorizer(deps.Db),
 		},
 	)
 
@@ -108,7 +108,7 @@ func RegisterGrpcServices(s *grpc.Server, deps *GrpcDependencies) {
 		s,
 		&AppserverSubGRPCService{
 			Deps: deps,
-			Auth: permission.NewAppserverSubAuthorizer(deps.DbConn, deps.Db),
+			Auth: permission.NewAppserverSubAuthorizer(deps.Db),
 		},
 	)
 
@@ -117,7 +117,7 @@ func RegisterGrpcServices(s *grpc.Server, deps *GrpcDependencies) {
 		s,
 		&ChannelGRPCService{
 			Deps: deps,
-			Auth: permission.NewChannelAuthorizer(deps.DbConn, deps.Db),
+			Auth: permission.NewChannelAuthorizer(deps.Db),
 		},
 	)
 
@@ -126,7 +126,7 @@ func RegisterGrpcServices(s *grpc.Server, deps *GrpcDependencies) {
 		s,
 		&ChannelRoleGRPCService{
 			Deps: deps,
-			Auth: permission.NewChannelRoleAuthorizer(deps.DbConn, deps.Db),
+			Auth: permission.NewChannelRoleAuthorizer(deps.Db),
 		},
 	)
 }

--- a/src/rpcs/base_test.go
+++ b/src/rpcs/base_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 func TestBaseInterceptors_Success(t *testing.T) {
-	t.Run("Successcreating_interceptors_does_not_fail", func(t *testing.T) {
+	t.Run("Success:creating_interceptors_does_not_fail", func(t *testing.T) {
 		opt, err := rpcs.BaseInterceptors()
 		assert.NotNil(t, opt)
 		assert.Nil(t, err)
 	})
 
-	t.Run("Successcreating_interceptors_does_not_fail", func(t *testing.T) {
+	t.Run("Success:creating_interceptors_does_not_fail", func(t *testing.T) {
 		// ARRANGE
 		mockValidator := new(testutil.MockProtovalidator)
 		// Backup and override the global validator creator

--- a/src/rpcs/channel.go
+++ b/src/rpcs/channel.go
@@ -17,15 +17,14 @@ func (s *ChannelGRPCService) Create(ctx context.Context, req *channel.CreateRequ
 	var err error
 
 	serverId, _ := uuid.Parse(req.AppserverId)
-	ctx = context.WithValue(
-		ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId},
-	)
+	ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId})
 
 	if err = s.Auth.Authorize(ctx, nil, permission.ActionCreate); err != nil {
 		return nil, faults.RpcCustomErrorHandler(ctx, faults.ExtendError(err))
 	}
+
 	cs := service.NewChannelService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 	c, err := cs.Create(qx.CreateChannelParams{Name: req.Name, AppserverID: serverId, IsPrivate: req.IsPrivate})
 
@@ -45,16 +44,14 @@ func (s *ChannelGRPCService) GetById(
 	var err error
 
 	serverId, _ := uuid.Parse(req.AppserverId)
-	ctx = context.WithValue(
-		ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId},
-	)
+	ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId})
 
 	if err = s.Auth.Authorize(ctx, &req.Id, permission.ActionRead); err != nil {
 		return nil, faults.RpcCustomErrorHandler(ctx, faults.ExtendError(err))
 	}
 
 	cs := service.NewChannelService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 	id, _ := uuid.Parse(req.Id)
 	c, err := cs.GetById(id)
@@ -82,7 +79,7 @@ func (s *ChannelGRPCService) ListServerChannels(
 	}
 
 	cs := service.NewChannelService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 
 	if req.Name != nil {
@@ -114,7 +111,7 @@ func (s *ChannelGRPCService) Delete(
 
 	id, _ := uuid.Parse(req.Id)
 	if err := service.NewChannelService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	).Delete(id); err != nil {
 		return nil, faults.RpcCustomErrorHandler(ctx, faults.ExtendError(err))
 	}

--- a/src/rpcs/channel_role.go
+++ b/src/rpcs/channel_role.go
@@ -19,9 +19,7 @@ func (s *ChannelRoleGRPCService) Create(
 	var err error
 
 	serverId, _ := uuid.Parse(req.AppserverId)
-	ctx = context.WithValue(
-		ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId},
-	)
+	ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId})
 
 	if err = s.Auth.Authorize(ctx, nil, permission.ActionCreate); err != nil {
 		return nil, faults.RpcCustomErrorHandler(ctx, faults.ExtendError(err))
@@ -31,7 +29,7 @@ func (s *ChannelRoleGRPCService) Create(
 	channelId, _ := uuid.Parse(req.ChannelId)
 
 	roleService := service.NewChannelRoleService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 	roles, err := roleService.Create(
 		qx.CreateChannelRoleParams{AppserverRoleID: roleId, AppserverID: serverId, ChannelID: channelId},
@@ -64,7 +62,7 @@ func (s *ChannelRoleGRPCService) ListChannelRoles(
 	}
 
 	roleService := service.NewChannelRoleService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	)
 	results, err := roleService.ListChannelRoles(channelId)
 
@@ -92,9 +90,7 @@ func (s *ChannelRoleGRPCService) Delete(
 	var err error
 
 	serverId, _ := uuid.Parse(req.AppserverId)
-	ctx = context.WithValue(
-		ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId},
-	)
+	ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: serverId})
 
 	if err = s.Auth.Authorize(ctx, &req.Id, permission.ActionDelete); err != nil {
 		return nil, faults.RpcCustomErrorHandler(ctx, faults.ExtendError(err))
@@ -105,7 +101,7 @@ func (s *ChannelRoleGRPCService) Delete(
 
 	// Call delete service method
 	err = service.NewChannelRoleService(
-		ctx, &service.ServiceDeps{Db: s.Deps.Db, DbConn: s.Deps.DbConn, MProducer: s.Deps.MProducer},
+		ctx, &service.ServiceDeps{Db: s.Deps.Db, MProducer: s.Deps.MProducer},
 	).Delete(roleId)
 
 	// Error handling

--- a/src/rpcs/channel_role_test.go
+++ b/src/rpcs/channel_role_test.go
@@ -238,9 +238,12 @@ func TestChannelRoleRPCService_Delete(t *testing.T) {
 	t.Run("Success:roles_can_be_deleted", func(t *testing.T) {
 		// ARRANGE
 		ctx, db := testutil.Setup(t, func() {})
-		channelRole := testutil.TestChannelRole(t, nil, true)
+		factory.UserAppserverOwner(t, ctx, db)
+		channelRole := factory.NewFactory(ctx, db).ChannelRole(t, 0, nil)
 
-		svc := &rpcs.ChannelRoleGRPCService{Deps: &rpcs.GrpcDependencies{Db: db}, Auth: testutil.TestMockAuth}
+		svc := &rpcs.ChannelRoleGRPCService{
+			Deps: &rpcs.GrpcDependencies{Db: db, MProducer: testutil.MockRedisProducer}, Auth: testutil.TestMockAuth,
+		}
 
 		// ACT
 		response, err := svc.Delete(

--- a/src/rpcs/channel_test.go
+++ b/src/rpcs/channel_test.go
@@ -26,14 +26,14 @@ func TestChannelRPCService_ListServerChannels(t *testing.T) {
 	t.Run("Success:returns_nothing_successfully", func(t *testing.T) {
 		// ARRANGE
 		ctx, db := testutil.Setup(t, func() {})
-		sub := testutil.TestAppserverSub(t, nil, true)
-		ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: sub.AppserverID})
+		su := factory.UserAppserverSub(t, ctx, db)
+		ctx = context.WithValue(ctx, permission.PermissionCtxKey, &permission.AppserverIdAuthCtx{AppserverId: su.Server.ID})
 
 		svc := &rpcs.ChannelGRPCService{Deps: &rpcs.GrpcDependencies{Db: db}, Auth: testutil.TestMockAuth}
 
 		// ACT
 		response, err := svc.ListServerChannels(
-			ctx, &channel.ListServerChannelsRequest{AppserverId: sub.AppserverID.String()},
+			ctx, &channel.ListServerChannelsRequest{AppserverId: su.Server.ID.String()},
 		)
 		if err != nil {
 			t.Fatalf("Error performing request %v", err)

--- a/src/service/appserver_role_sub_test.go
+++ b/src/service/appserver_role_sub_test.go
@@ -29,7 +29,6 @@ func TestAppserverRoleSubService_PgTypeToPb(t *testing.T) {
 	svc := service.NewAppserverRoleSubService(
 		context.Background(),
 		&service.ServiceDeps{
-			DbConn:    testutil.TestDbConn,
 			Db:        new(testutil.MockQuerier),
 			MProducer: producer.NewMProducer(new(testutil.MockRedis)),
 		},
@@ -47,9 +46,9 @@ func TestAppserverRoleSubService_PgTypeToPb(t *testing.T) {
 
 func TestAppserverRoleSubService_Create(t *testing.T) {
 
-	t.Run("Successcreate_role_sub", func(t *testing.T) {
+	t.Run("Success:create_role_sub", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		obj := qx.CreateAppserverRoleSubParams{
 			AppserverRoleID: uuid.New(),
 			AppuserID:       uuid.New(),
@@ -70,7 +69,7 @@ func TestAppserverRoleSubService_Create(t *testing.T) {
 		mockQuerier.On("GetChannelsForUsers", ctx, mock.Anything).Return([]qx.GetChannelsForUsersRow{}, nil)
 
 		svc := service.NewAppserverRoleSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -85,7 +84,7 @@ func TestAppserverRoleSubService_Create(t *testing.T) {
 
 	t.Run("Error:on_create_failure", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		obj := qx.CreateAppserverRoleSubParams{
 			AppserverRoleID: uuid.New(),
 			AppuserID:       uuid.New(),
@@ -99,7 +98,7 @@ func TestAppserverRoleSubService_Create(t *testing.T) {
 		mockQuerier.On("CreateAppserverRoleSub", ctx, obj).Return(nil, fmt.Errorf("insert failed"))
 
 		svc := service.NewAppserverRoleSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -116,9 +115,9 @@ func TestAppserverRoleSubService_Create(t *testing.T) {
 
 func TestAppserverRoleSubService_ListServerRoleSubs(t *testing.T) {
 
-	t.Run("Successfetch_role_subs", func(t *testing.T) {
+	t.Run("Success:fetch_role_subs", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		appserverId := uuid.New()
 		expected := []qx.ListServerRoleSubsRow{
 			{AppuserID: uuid.New(), AppserverRoleID: uuid.New()},
@@ -131,7 +130,7 @@ func TestAppserverRoleSubService_ListServerRoleSubs(t *testing.T) {
 		mockQuerier.On("ListServerRoleSubs", ctx, appserverId).Return(expected, nil)
 
 		svc := service.NewAppserverRoleSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -146,7 +145,7 @@ func TestAppserverRoleSubService_ListServerRoleSubs(t *testing.T) {
 
 	t.Run("Error:on_db_failure", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		appserverId := uuid.New()
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -158,7 +157,7 @@ func TestAppserverRoleSubService_ListServerRoleSubs(t *testing.T) {
 		)
 
 		svc := service.NewAppserverRoleSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -175,9 +174,9 @@ func TestAppserverRoleSubService_ListServerRoleSubs(t *testing.T) {
 
 func TestAppserverRoleSubService_GetById(t *testing.T) {
 
-	t.Run("Successreturn_appserver_role_sub_object", func(t *testing.T) {
+	t.Run("Success:return_appserver_role_sub_object", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		roleId := uuid.New()
 		expected := qx.AppserverRoleSub{
 			ID: uuid.New(), AppuserID: uuid.New(), AppserverRoleID: uuid.New(), AppserverSubID: uuid.New(),
@@ -191,7 +190,7 @@ func TestAppserverRoleSubService_GetById(t *testing.T) {
 		mockQuerier.On("GetAppserverRoleSubById", ctx, roleId).Return(expected, nil)
 
 		svc := service.NewAppserverRoleSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -210,7 +209,7 @@ func TestAppserverRoleSubService_GetById(t *testing.T) {
 
 	t.Run("Error:returns_not_found_when_no_rows", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		appserverId := uuid.New()
 		mockQuerier := new(testutil.MockQuerier)
 		mockRedis := new(testutil.MockRedis)
@@ -219,7 +218,7 @@ func TestAppserverRoleSubService_GetById(t *testing.T) {
 		mockQuerier.On("GetAppserverRoleSubById", ctx, appserverId).Return(nil, fmt.Errorf(message.DbNotFound))
 
 		svc := service.NewAppserverRoleSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -235,7 +234,7 @@ func TestAppserverRoleSubService_GetById(t *testing.T) {
 
 	t.Run("Error:returns_database_error_on_failure", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		appserverId := uuid.New()
 		mockQuerier := new(testutil.MockQuerier)
 		mockRedis := new(testutil.MockRedis)
@@ -244,7 +243,7 @@ func TestAppserverRoleSubService_GetById(t *testing.T) {
 		mockQuerier.On("GetAppserverRoleSubById", ctx, appserverId).Return(nil, fmt.Errorf("boom"))
 
 		svc := service.NewAppserverRoleSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -261,9 +260,9 @@ func TestAppserverRoleSubService_GetById(t *testing.T) {
 
 func TestAppserverRoleSubService_Delete(t *testing.T) {
 
-	t.Run("Successdelete_role_sub", func(t *testing.T) {
+	t.Run("Success:delete_role_sub", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		roleSub := qx.AppserverRoleSub{
 			ID:              uuid.New(),
 			AppserverRoleID: uuid.New(),
@@ -281,7 +280,7 @@ func TestAppserverRoleSubService_Delete(t *testing.T) {
 		mockQuerier.On("GetChannelsForUsers", ctx, mock.Anything).Return([]qx.GetChannelsForUsersRow{}, nil)
 
 		svc := service.NewAppserverRoleSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -295,7 +294,7 @@ func TestAppserverRoleSubService_Delete(t *testing.T) {
 
 	t.Run("Error:no_rows_deleted", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		roleSub := qx.AppserverRoleSub{
 			ID:              uuid.New(),
 			AppserverRoleID: uuid.New(),
@@ -312,7 +311,7 @@ func TestAppserverRoleSubService_Delete(t *testing.T) {
 		mockQuerier.On("GetAppserverRoleSubById", ctx, roleSub.ID).Return(roleSub, nil)
 
 		svc := service.NewAppserverRoleSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -330,7 +329,7 @@ func TestAppserverRoleSubService_Delete(t *testing.T) {
 
 	t.Run("Error:db_failure_on_delete_role_sub", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		roleSub := qx.AppserverRoleSub{
 			ID:              uuid.New(),
 			AppserverRoleID: uuid.New(),
@@ -347,7 +346,7 @@ func TestAppserverRoleSubService_Delete(t *testing.T) {
 		mockQuerier.On("DeleteAppserverRoleSub", ctx, roleSub.ID).Return(nil, fmt.Errorf("db crash"))
 
 		svc := service.NewAppserverRoleSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -363,7 +362,7 @@ func TestAppserverRoleSubService_Delete(t *testing.T) {
 
 	t.Run("Error:db_failure_on_get_role_sub_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		roleSub := qx.AppserverRoleSub{
 			ID: uuid.New(),
 		}
@@ -375,7 +374,7 @@ func TestAppserverRoleSubService_Delete(t *testing.T) {
 		mockQuerier.On("GetAppserverRoleSubById", ctx, roleSub.ID).Return(nil, fmt.Errorf("db crash"))
 
 		svc := service.NewAppserverRoleSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT

--- a/src/service/appserver_role_test.go
+++ b/src/service/appserver_role_test.go
@@ -46,7 +46,6 @@ func TestAppserverRoleService_PgTypeToPb(t *testing.T) {
 	svc := service.NewAppserverRoleService(
 		context.Background(),
 		&service.ServiceDeps{
-			DbConn:    testutil.TestDbConn,
 			Db:        new(testutil.MockQuerier),
 			MProducer: producer.NewMProducer(new(testutil.MockRedis)),
 		},
@@ -61,9 +60,9 @@ func TestAppserverRoleService_PgTypeToPb(t *testing.T) {
 
 func TestAppserverRoleService_Create(t *testing.T) {
 
-	t.Run("Successcreate_role", func(t *testing.T) {
+	t.Run("Success:create_role", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		obj := qx.CreateAppserverRoleParams{AppserverID: uuid.New(), Name: "editor"}
 		expected := qx.AppserverRole{ID: uuid.New(), AppserverID: obj.AppserverID, Name: obj.Name}
 
@@ -74,7 +73,7 @@ func TestAppserverRoleService_Create(t *testing.T) {
 		mockQuerier.On("CreateAppserverRole", ctx, obj).Return(expected, nil)
 
 		svc := service.NewAppserverRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -89,7 +88,7 @@ func TestAppserverRoleService_Create(t *testing.T) {
 
 	t.Run("Error:on_create_failure", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		obj := qx.CreateAppserverRoleParams{AppserverID: uuid.New(), Name: "viewer"}
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -99,7 +98,7 @@ func TestAppserverRoleService_Create(t *testing.T) {
 		mockQuerier.On("CreateAppserverRole", ctx, obj).Return(nil, fmt.Errorf("creation failed"))
 
 		svc := service.NewAppserverRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -115,9 +114,9 @@ func TestAppserverRoleService_Create(t *testing.T) {
 
 func TestAppserverRoleService_ListAppserverRoles(t *testing.T) {
 
-	t.Run("Successlist_roles", func(t *testing.T) {
+	t.Run("Success:list_roles", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		appserverId := uuid.New()
 		expected := []qx.AppserverRole{{ID: uuid.New(), AppserverID: appserverId, Name: "admin"}}
 
@@ -128,7 +127,7 @@ func TestAppserverRoleService_ListAppserverRoles(t *testing.T) {
 		mockQuerier.On("ListAppserverRoles", ctx, appserverId).Return(expected, nil)
 
 		svc := service.NewAppserverRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -142,7 +141,7 @@ func TestAppserverRoleService_ListAppserverRoles(t *testing.T) {
 
 	t.Run("Error:on_db_failure", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		appserverId := uuid.New()
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -152,7 +151,7 @@ func TestAppserverRoleService_ListAppserverRoles(t *testing.T) {
 		mockQuerier.On("ListAppserverRoles", ctx, appserverId).Return(nil, fmt.Errorf("db error"))
 
 		svc := service.NewAppserverRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -168,9 +167,9 @@ func TestAppserverRoleService_ListAppserverRoles(t *testing.T) {
 
 func TestAppserverRoleService_GetAppuserRoles(t *testing.T) {
 
-	t.Run("Successgets_roles", func(t *testing.T) {
+	t.Run("Success:gets_roles", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		expectedRequest := qx.GetAppuserRolesParams{
 			AppserverID: uuid.New(),
 			AppuserID:   uuid.New(),
@@ -184,7 +183,7 @@ func TestAppserverRoleService_GetAppuserRoles(t *testing.T) {
 		mockQuerier.On("GetAppuserRoles", ctx, expectedRequest).Return(expected, nil)
 
 		svc := service.NewAppserverRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -198,7 +197,7 @@ func TestAppserverRoleService_GetAppuserRoles(t *testing.T) {
 
 	t.Run("Error:on_db_failure", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		expectedRequest := qx.GetAppuserRolesParams{
 			AppserverID: uuid.New(),
 			AppuserID:   uuid.New(),
@@ -210,7 +209,7 @@ func TestAppserverRoleService_GetAppuserRoles(t *testing.T) {
 		mockQuerier.On("GetAppuserRoles", ctx, expectedRequest).Return(nil, fmt.Errorf("db error"))
 
 		svc := service.NewAppserverRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -226,9 +225,9 @@ func TestAppserverRoleService_GetAppuserRoles(t *testing.T) {
 
 func TestAppserverRoleService_GetById(t *testing.T) {
 
-	t.Run("Successreturns_appserver_role_object", func(t *testing.T) {
+	t.Run("Success:returns_appserver_role_object", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		roleId := uuid.New()
 		expected := qx.AppserverRole{ID: roleId, Name: "test-app"}
 
@@ -239,7 +238,7 @@ func TestAppserverRoleService_GetById(t *testing.T) {
 		mockQuerier.On("GetAppserverRoleById", ctx, roleId).Return(expected, nil)
 
 		svc := service.NewAppserverRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -254,7 +253,7 @@ func TestAppserverRoleService_GetById(t *testing.T) {
 
 	t.Run("Error:returns_not_found_when_no_rows", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		appserverId := uuid.New()
 		mockQuerier := new(testutil.MockQuerier)
 		mockRedis := new(testutil.MockRedis)
@@ -263,7 +262,7 @@ func TestAppserverRoleService_GetById(t *testing.T) {
 		mockQuerier.On("GetAppserverRoleById", ctx, appserverId).Return(nil, fmt.Errorf(message.DbNotFound))
 
 		svc := service.NewAppserverRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -277,7 +276,7 @@ func TestAppserverRoleService_GetById(t *testing.T) {
 
 	t.Run("Error:returns_database_error_on_failure", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		appserverId := uuid.New()
 		mockQuerier := new(testutil.MockQuerier)
 		mockRedis := new(testutil.MockRedis)
@@ -286,7 +285,7 @@ func TestAppserverRoleService_GetById(t *testing.T) {
 		mockQuerier.On("GetAppserverRoleById", ctx, appserverId).Return(nil, fmt.Errorf("boom"))
 
 		svc := service.NewAppserverRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -302,9 +301,9 @@ func TestAppserverRoleService_GetById(t *testing.T) {
 
 func TestAppserverRoleService_Delete(t *testing.T) {
 
-	t.Run("Successdelete_role", func(t *testing.T) {
+	t.Run("Success:delete_role", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		params := uuid.New()
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -314,7 +313,7 @@ func TestAppserverRoleService_Delete(t *testing.T) {
 		mockQuerier.On("DeleteAppserverRole", ctx, params).Return(int64(1), nil)
 
 		svc := service.NewAppserverRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -327,7 +326,7 @@ func TestAppserverRoleService_Delete(t *testing.T) {
 
 	t.Run("Error:no_rows_deleted", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		params := uuid.New()
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -337,7 +336,7 @@ func TestAppserverRoleService_Delete(t *testing.T) {
 		mockQuerier.On("DeleteAppserverRole", ctx, params).Return(int64(0), nil)
 
 		svc := service.NewAppserverRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -352,7 +351,7 @@ func TestAppserverRoleService_Delete(t *testing.T) {
 
 	t.Run("Error:db_failure_on_delete", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		params := uuid.New()
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -362,7 +361,7 @@ func TestAppserverRoleService_Delete(t *testing.T) {
 		mockQuerier.On("DeleteAppserverRole", ctx, params).Return(nil, fmt.Errorf("db crash"))
 
 		svc := service.NewAppserverRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT

--- a/src/service/appserver_sub.go
+++ b/src/service/appserver_sub.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"mist/src/faults"
@@ -68,19 +67,12 @@ func (s *AppserverSubService) PgUserSubRowToPb(res *qx.ListAppserverUserSubsRow)
 
 // Creates a user to server subscription
 func (s *AppserverSubService) Create(obj qx.CreateAppserverSubParams) (*qx.AppserverSub, error) {
+	fmt.Println(s.ctx, obj, s.deps.Db)
 	appserverSub, err := s.deps.Db.CreateAppserverSub(s.ctx, obj)
 
 	if err != nil {
 		return nil, faults.DatabaseError(fmt.Sprintf("database error: %v", err), slog.LevelError)
 	}
-
-	return &appserverSub, err
-}
-
-// Creates a user to server subscription using injected transaction, does not commit the transaction.
-func (s *AppserverSubService) CreateWithTx(obj qx.CreateAppserverSubParams, tx pgx.Tx) (*qx.AppserverSub, error) {
-	txQ := s.deps.Db.WithTx(tx)
-	appserverSub, err := txQ.CreateAppserverSub(s.ctx, obj)
 
 	return &appserverSub, err
 }

--- a/src/service/appserver_sub.go
+++ b/src/service/appserver_sub.go
@@ -67,7 +67,6 @@ func (s *AppserverSubService) PgUserSubRowToPb(res *qx.ListAppserverUserSubsRow)
 
 // Creates a user to server subscription
 func (s *AppserverSubService) Create(obj qx.CreateAppserverSubParams) (*qx.AppserverSub, error) {
-	fmt.Println(s.ctx, obj, s.deps.Db)
 	appserverSub, err := s.deps.Db.CreateAppserverSub(s.ctx, obj)
 
 	if err != nil {

--- a/src/service/appserver_sub_test.go
+++ b/src/service/appserver_sub_test.go
@@ -48,7 +48,6 @@ func TestAppserverSubService_PgTypeToPb(t *testing.T) {
 		context.Background(),
 		&service.ServiceDeps{
 			Db:        new(testutil.MockQuerier),
-			DbConn:    testutil.TestDbConn,
 			MProducer: producer.NewMProducer(new(testutil.MockRedis)),
 		},
 	)
@@ -75,7 +74,6 @@ func TestAppserverSubService_PgAppserverSubRowToPb(t *testing.T) {
 		context.Background(),
 		&service.ServiceDeps{
 			Db:        new(testutil.MockQuerier),
-			DbConn:    testutil.TestDbConn,
 			MProducer: producer.NewMProducer(new(testutil.MockRedis)),
 		},
 	)
@@ -104,7 +102,6 @@ func TestAppserverSubService_PgUserSubRowToPb(t *testing.T) {
 		context.Background(),
 		&service.ServiceDeps{
 			Db:        new(testutil.MockQuerier),
-			DbConn:    testutil.TestDbConn,
 			MProducer: producer.NewMProducer(new(testutil.MockRedis)),
 		},
 	)
@@ -120,9 +117,9 @@ func TestAppserverSubService_PgUserSubRowToPb(t *testing.T) {
 
 func TestAppserverSubService_Create(t *testing.T) {
 
-	t.Run("Successcreate_sub", func(t *testing.T) {
+	t.Run("Success:create_sub", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		obj := qx.CreateAppserverSubParams{AppserverID: uuid.New(), AppuserID: uuid.New()}
 		expected := qx.AppserverSub{ID: uuid.New(), AppserverID: obj.AppserverID, AppuserID: obj.AppuserID}
 
@@ -133,7 +130,7 @@ func TestAppserverSubService_Create(t *testing.T) {
 		mockQuerier.On("CreateAppserverSub", ctx, obj).Return(expected, nil)
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -147,7 +144,7 @@ func TestAppserverSubService_Create(t *testing.T) {
 
 	t.Run("Error:failed_to_create", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		obj := qx.CreateAppserverSubParams{AppserverID: uuid.New(), AppuserID: uuid.New()}
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -157,7 +154,7 @@ func TestAppserverSubService_Create(t *testing.T) {
 		mockQuerier.On("CreateAppserverSub", ctx, obj).Return(nil, fmt.Errorf("create error"))
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -174,9 +171,9 @@ func TestAppserverSubService_Create(t *testing.T) {
 
 func TestAppserverSubService_ListUserServerSubs(t *testing.T) {
 
-	t.Run("Successlist_subs_for_user", func(t *testing.T) {
+	t.Run("Success:list_subs_for_user", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
 		expected := []qx.ListUserServerSubsRow{
 			{
@@ -194,7 +191,7 @@ func TestAppserverSubService_ListUserServerSubs(t *testing.T) {
 		mockQuerier.On("ListUserServerSubs", ctx, userID).Return(expected, nil)
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -208,7 +205,7 @@ func TestAppserverSubService_ListUserServerSubs(t *testing.T) {
 
 	t.Run("Error:on_db_error", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		userID := uuid.New()
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -220,7 +217,7 @@ func TestAppserverSubService_ListUserServerSubs(t *testing.T) {
 		)
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -236,9 +233,9 @@ func TestAppserverSubService_ListUserServerSubs(t *testing.T) {
 
 func TestAppserverSubService_ListAppserverUserSubs(t *testing.T) {
 
-	t.Run("Successlist_users_in_server", func(t *testing.T) {
+	t.Run("Success:list_users_in_server", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		serverID := uuid.New()
 		expected := []qx.ListAppserverUserSubsRow{
 			{
@@ -256,7 +253,7 @@ func TestAppserverSubService_ListAppserverUserSubs(t *testing.T) {
 		mockQuerier.On("ListAppserverUserSubs", ctx, serverID).Return(expected, nil)
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -270,7 +267,7 @@ func TestAppserverSubService_ListAppserverUserSubs(t *testing.T) {
 
 	t.Run("Error:on_db_error", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		serverID := uuid.New()
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -280,7 +277,7 @@ func TestAppserverSubService_ListAppserverUserSubs(t *testing.T) {
 		mockQuerier.On("ListAppserverUserSubs", ctx, serverID).Return(nil, fmt.Errorf("query error"))
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -296,9 +293,9 @@ func TestAppserverSubService_ListAppserverUserSubs(t *testing.T) {
 
 func TestAppserverSubService_GetById(t *testing.T) {
 
-	t.Run("Successreturns_appserver_sub_object", func(t *testing.T) {
+	t.Run("Success:returns_appserver_sub_object", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		expected := qx.AppserverSub{ID: uuid.New(), AppserverID: uuid.New(), AppuserID: uuid.New()}
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -308,7 +305,7 @@ func TestAppserverSubService_GetById(t *testing.T) {
 		mockQuerier.On("GetAppserverSubById", ctx, expected.ID).Return(expected, nil)
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -324,7 +321,7 @@ func TestAppserverSubService_GetById(t *testing.T) {
 
 	t.Run("Error:returns_not_found_when_no_rows", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		appserverId := uuid.New()
 		mockQuerier := new(testutil.MockQuerier)
 		mockRedis := new(testutil.MockRedis)
@@ -333,7 +330,7 @@ func TestAppserverSubService_GetById(t *testing.T) {
 		mockQuerier.On("GetAppserverSubById", ctx, appserverId).Return(nil, fmt.Errorf(message.DbNotFound))
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -348,7 +345,7 @@ func TestAppserverSubService_GetById(t *testing.T) {
 
 	t.Run("Error:returns_database_error_on_failure", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		appserverId := uuid.New()
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -358,7 +355,7 @@ func TestAppserverSubService_GetById(t *testing.T) {
 		mockQuerier.On("GetAppserverSubById", ctx, appserverId).Return(nil, fmt.Errorf("boom"))
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -375,9 +372,9 @@ func TestAppserverSubService_GetById(t *testing.T) {
 
 func TestAppserverSubService_Filter(t *testing.T) {
 
-	t.Run("Successfilters_subs", func(t *testing.T) {
+	t.Run("Success:filters_subs", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		args := qx.FilterAppserverSubParams{
 			AppuserID:   pgtype.UUID{Valid: true, Bytes: uuid.New()},
 			AppserverID: pgtype.UUID{Valid: true, Bytes: uuid.New()},
@@ -399,7 +396,7 @@ func TestAppserverSubService_Filter(t *testing.T) {
 		mockQuerier.On("FilterAppserverSub", ctx, args).Return(expected, nil)
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -413,7 +410,7 @@ func TestAppserverSubService_Filter(t *testing.T) {
 
 	t.Run("Error:on_db_failure", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		args := qx.FilterAppserverSubParams{
 			AppuserID:   pgtype.UUID{Valid: true, Bytes: uuid.New()},
 			AppserverID: pgtype.UUID{Valid: true, Bytes: uuid.New()},
@@ -426,7 +423,7 @@ func TestAppserverSubService_Filter(t *testing.T) {
 		mockQuerier.On("FilterAppserverSub", ctx, args).Return(nil, fmt.Errorf("some db failure"))
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -443,13 +440,10 @@ func TestAppserverSubService_Filter(t *testing.T) {
 
 func TestAppserverSubService_Delete(t *testing.T) {
 
-	t.Run("Successdeletes_sub", func(t *testing.T) {
+	t.Run("Success:deletes_sub", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
-		mockSub := qx.AppserverSub{
-			ID:        uuid.New(),
-			AppuserID: uuid.New(),
-		}
+		ctx, _ := testutil.Setup(t, func() {})
+		mockSub := qx.AppserverSub{ID: uuid.New(), AppuserID: uuid.New()}
 
 		mockQuerier := new(testutil.MockQuerier)
 		mockRedis := new(testutil.MockRedis)
@@ -460,7 +454,7 @@ func TestAppserverSubService_Delete(t *testing.T) {
 		mockRedis.On("Publish", ctx, os.Getenv("REDIS_NOTIFICATION_CHANNEL"), mock.Anything).Return(redis.NewIntCmd(ctx))
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -474,11 +468,8 @@ func TestAppserverSubService_Delete(t *testing.T) {
 
 	t.Run("Error:returns_not_found_if_no_rows_deleted", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
-		mockSub := qx.AppserverSub{
-			ID:        uuid.New(),
-			AppuserID: uuid.New(),
-		}
+		ctx, _ := testutil.Setup(t, func() {})
+		mockSub := qx.AppserverSub{ID: uuid.New(), AppuserID: uuid.New()}
 
 		mockQuerier := new(testutil.MockQuerier)
 		mockRedis := new(testutil.MockRedis)
@@ -488,7 +479,7 @@ func TestAppserverSubService_Delete(t *testing.T) {
 		mockQuerier.On("GetAppserverSubById", mock.Anything, mockSub.ID).Return(mockSub, nil)
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -503,11 +494,8 @@ func TestAppserverSubService_Delete(t *testing.T) {
 
 	t.Run("Error:returns_error_on_db_fail", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
-		mockSub := qx.AppserverSub{
-			ID:        uuid.New(),
-			AppuserID: uuid.New(),
-		}
+		ctx, _ := testutil.Setup(t, func() {})
+		mockSub := qx.AppserverSub{ID: uuid.New(), AppuserID: uuid.New()}
 
 		mockQuerier := new(testutil.MockQuerier)
 		mockRedis := new(testutil.MockRedis)
@@ -517,7 +505,7 @@ func TestAppserverSubService_Delete(t *testing.T) {
 		mockQuerier.On("GetAppserverSubById", mock.Anything, mockSub.ID).Return(mockSub, nil)
 
 		svc := service.NewAppserverSubService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT

--- a/src/service/appuser_test.go
+++ b/src/service/appuser_test.go
@@ -26,7 +26,6 @@ func TestAppuserService_PgTypeToPb(t *testing.T) {
 	svc := service.NewAppuserService(
 		ctx,
 		&service.ServiceDeps{
-			DbConn:    testutil.TestDbConn,
 			Db:        new(testutil.MockQuerier),
 			MProducer: producer.NewMProducer(new(testutil.MockRedis)),
 		},
@@ -47,9 +46,9 @@ func TestAppuserService_PgTypeToPb(t *testing.T) {
 
 func TestAppuserService_Create(t *testing.T) {
 
-	t.Run("Successcan_create_user", func(t *testing.T) {
+	t.Run("Success:can_create_user", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		expectedUser := qx.Appuser{ID: uuid.New(), Username: "testuser"}
 		params := qx.CreateAppuserParams{Username: expectedUser.Username}
 
@@ -60,7 +59,7 @@ func TestAppuserService_Create(t *testing.T) {
 		mockQuerier.On("CreateAppuser", ctx, params).Return(expectedUser, nil)
 
 		svc := service.NewAppuserService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -75,7 +74,7 @@ func TestAppuserService_Create(t *testing.T) {
 
 	t.Run("Error:failure_on_db_error", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		params := qx.CreateAppuserParams{Username: "baduser"}
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -85,7 +84,7 @@ func TestAppuserService_Create(t *testing.T) {
 		mockQuerier.On("CreateAppuser", ctx, params).Return(nil, fmt.Errorf("db error"))
 
 		svc := service.NewAppuserService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT

--- a/src/service/base.go
+++ b/src/service/base.go
@@ -3,12 +3,9 @@ package service
 import (
 	"mist/src/producer"
 	"mist/src/psql_db/db"
-
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type ServiceDeps struct {
 	Db        db.Querier
-	DbConn    *pgxpool.Pool
 	MProducer *producer.MProducer
 }

--- a/src/service/channel.go
+++ b/src/service/channel.go
@@ -102,10 +102,10 @@ func (s *ChannelService) Filter(obj qx.FilterChannelParams) ([]qx.Channel, error
 func (s *ChannelService) Delete(id uuid.UUID) error {
 	// TODO: doing double queries here "fetching" the sub and then deleting it. maybe change this so that
 	// we can do it in one query.
-	channel, err := s.deps.Db.GetChannelById(s.ctx, id)
+	channel, err := s.GetById(id)
 
 	if err != nil {
-		return faults.DatabaseError(fmt.Sprintf("error deleting channel: %v", err), slog.LevelError)
+		return faults.ExtendError(err)
 	}
 
 	deleted, err := s.deps.Db.DeleteChannel(s.ctx, id)

--- a/src/service/channel_role_test.go
+++ b/src/service/channel_role_test.go
@@ -47,7 +47,6 @@ func TestChannelRoleService_PgTypeToPb(t *testing.T) {
 		context.Background(),
 		&service.ServiceDeps{
 			Db:        new(testutil.MockQuerier),
-			DbConn:    testutil.TestDbConn,
 			MProducer: producer.NewMProducer(new(testutil.MockRedis)),
 		})
 
@@ -59,9 +58,9 @@ func TestChannelRoleService_PgTypeToPb(t *testing.T) {
 }
 
 func TestChannelRoleService_Create(t *testing.T) {
-	t.Run("Successcreate_channel_role", func(t *testing.T) {
+	t.Run("Success:create_channel_role", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		obj := qx.CreateChannelRoleParams{ChannelID: uuid.New(), AppserverRoleID: uuid.New()}
 		expected := qx.ChannelRole{ID: uuid.New(), ChannelID: obj.ChannelID, AppserverRoleID: obj.AppserverRoleID}
 
@@ -73,7 +72,7 @@ func TestChannelRoleService_Create(t *testing.T) {
 		mockQuerier.On("ListAppserverUserSubs", ctx, obj.AppserverID).Return([]qx.ListAppserverUserSubsRow{}, nil)
 
 		svc := service.NewChannelRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -88,7 +87,7 @@ func TestChannelRoleService_Create(t *testing.T) {
 
 	t.Run("Error:on_create_failure", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		obj := qx.CreateChannelRoleParams{ChannelID: uuid.New(), AppserverRoleID: uuid.New()}
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -97,7 +96,7 @@ func TestChannelRoleService_Create(t *testing.T) {
 
 		mockQuerier.On("CreateChannelRole", ctx, obj).Return(nil, fmt.Errorf("creation failed"))
 		svc := service.NewChannelRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -113,9 +112,9 @@ func TestChannelRoleService_Create(t *testing.T) {
 }
 
 func TestChannelRoleService_ListChannelRoles(t *testing.T) {
-	t.Run("Successlist_roles", func(t *testing.T) {
+	t.Run("Success:list_roles", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		channelId := uuid.New()
 		expected := []qx.ChannelRole{{ID: uuid.New(), ChannelID: channelId, AppserverRoleID: uuid.New()}}
 
@@ -126,7 +125,7 @@ func TestChannelRoleService_ListChannelRoles(t *testing.T) {
 		mockQuerier.On("ListChannelRoles", ctx, channelId).Return(expected, nil)
 
 		svc := service.NewChannelRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -141,7 +140,7 @@ func TestChannelRoleService_ListChannelRoles(t *testing.T) {
 
 	t.Run("Error:on_db_failure", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		channelId := uuid.New()
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -151,7 +150,7 @@ func TestChannelRoleService_ListChannelRoles(t *testing.T) {
 		mockQuerier.On("ListChannelRoles", ctx, channelId).Return(nil, fmt.Errorf("db error"))
 
 		svc := service.NewChannelRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -167,9 +166,9 @@ func TestChannelRoleService_ListChannelRoles(t *testing.T) {
 }
 
 func TestChannelRoleService_GetById(t *testing.T) {
-	t.Run("Successreturns_channel_role", func(t *testing.T) {
+	t.Run("Success:returns_channel_role", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		roleId := uuid.New()
 		expected := qx.ChannelRole{ID: roleId, ChannelID: uuid.New()}
 
@@ -180,7 +179,7 @@ func TestChannelRoleService_GetById(t *testing.T) {
 		mockQuerier.On("GetChannelRoleById", ctx, roleId).Return(expected, nil)
 
 		svc := service.NewChannelRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -195,7 +194,7 @@ func TestChannelRoleService_GetById(t *testing.T) {
 
 	t.Run("Error:returns_not_found", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		roleId := uuid.New()
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -205,7 +204,7 @@ func TestChannelRoleService_GetById(t *testing.T) {
 		mockQuerier.On("GetChannelRoleById", ctx, roleId).Return(qx.ChannelRole{}, fmt.Errorf(message.DbNotFound))
 
 		svc := service.NewChannelRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -221,7 +220,7 @@ func TestChannelRoleService_GetById(t *testing.T) {
 
 	t.Run("Error:returns_db_error", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		roleId := uuid.New()
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -231,7 +230,7 @@ func TestChannelRoleService_GetById(t *testing.T) {
 		mockQuerier.On("GetChannelRoleById", ctx, roleId).Return(qx.ChannelRole{}, fmt.Errorf("boom"))
 
 		svc := service.NewChannelRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -247,9 +246,9 @@ func TestChannelRoleService_GetById(t *testing.T) {
 }
 
 func TestChannelRoleService_Delete(t *testing.T) {
-	t.Run("Successdelete_role", func(t *testing.T) {
+	t.Run("Success:delete_role", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		channel := qx.Channel{ID: uuid.New()}
 		channelRole := qx.ChannelRole{
 			ID: uuid.New(), AppserverRoleID: uuid.New(), ChannelID: channel.ID, AppserverID: uuid.New(),
@@ -264,7 +263,7 @@ func TestChannelRoleService_Delete(t *testing.T) {
 		mockQuerier.On("ListAppserverUserSubs", ctx, channelRole.AppserverID).Return([]qx.ListAppserverUserSubsRow{}, nil)
 
 		svc := service.NewChannelRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -278,7 +277,7 @@ func TestChannelRoleService_Delete(t *testing.T) {
 
 	t.Run("Error:no_rows_deleted", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		channel := qx.Channel{ID: uuid.New(), IsPrivate: true}
 		channelRole := qx.ChannelRole{ID: uuid.New(), AppserverRoleID: uuid.New(), ChannelID: channel.ID}
 
@@ -290,7 +289,7 @@ func TestChannelRoleService_Delete(t *testing.T) {
 		mockQuerier.On("DeleteChannelRole", ctx, channelRole.ID).Return(int64(0), nil)
 
 		svc := service.NewChannelRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -306,7 +305,7 @@ func TestChannelRoleService_Delete(t *testing.T) {
 
 	t.Run("Error:db_failure_on_get_channel_role_by_id", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		channelRole := qx.ChannelRole{ID: uuid.New()}
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -316,7 +315,7 @@ func TestChannelRoleService_Delete(t *testing.T) {
 		mockQuerier.On("GetChannelRoleById", ctx, channelRole.ID).Return(nil, fmt.Errorf("boom"))
 
 		svc := service.NewChannelRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT
@@ -332,7 +331,7 @@ func TestChannelRoleService_Delete(t *testing.T) {
 
 	t.Run("Error:db_failure_on_delete", func(t *testing.T) {
 		// ARRANGE
-		ctx := testutil.Setup(t, func() {})
+		ctx, _ := testutil.Setup(t, func() {})
 		channelRole := qx.ChannelRole{ID: uuid.New()}
 
 		mockQuerier := new(testutil.MockQuerier)
@@ -343,7 +342,7 @@ func TestChannelRoleService_Delete(t *testing.T) {
 		mockQuerier.On("DeleteChannelRole", ctx, channelRole.ID).Return(nil, fmt.Errorf("db crash"))
 
 		svc := service.NewChannelRoleService(
-			ctx, &service.ServiceDeps{Db: mockQuerier, DbConn: testutil.TestDbConn, MProducer: producer},
+			ctx, &service.ServiceDeps{Db: mockQuerier, MProducer: producer},
 		)
 
 		// ACT

--- a/src/testutil/factory/factory.go
+++ b/src/testutil/factory/factory.go
@@ -1,107 +1,410 @@
 package factory
 
 import (
-	"mist/src/permission"
+	"context"
+	"mist/src/psql_db/db"
 	"mist/src/psql_db/qx"
-	"mist/src/testutil"
 	"testing"
 )
 
-type testUser struct {
-	User   *qx.Appuser
-	Server *qx.Appserver
-	Sub    *qx.AppserverSub
+type Factory struct {
+	ctx context.Context
+	db  db.Querier
 }
 
-// Returns a testUser that owns a server.
-func UserAppserverOwner(t *testing.T) *testUser {
+func NewFactory(ctx context.Context, db db.Querier) *Factory {
+	return &Factory{
+		ctx: ctx,
+		db:  db,
+	}
+}
+
+func (f *Factory) Appuser(t *testing.T, index int, appuser *qx.Appuser) *qx.Appuser {
+	if index < 0 || index >= len(fakeAppusers) {
+		t.Fatalf("Invalid factory index: %d", index)
+	}
+
 	var (
-		u   *qx.Appuser
-		s   *qx.Appserver
-		sub *qx.AppserverSub
+		u   qx.Appuser
+		err error
 	)
-	u = testutil.TestAppuser(t, nil, true)
-	s = testutil.TestAppserver(t, nil, true)
-	sub = testutil.TestAppserverSub(t, &qx.AppserverSub{AppserverID: s.ID, AppuserID: u.ID}, false)
 
-	return &testUser{User: u, Server: s, Sub: sub}
+	if appuser != nil {
+		// with provided appuser, create using that one
+		u, err = f.db.GetAppuserById(f.ctx, appuser.ID)
+
+		if err == nil {
+			// if appuser exists, return it else create a new one
+			return &u
+		}
+
+		u, err = f.db.CreateAppuser(
+			f.ctx, qx.CreateAppuserParams{
+				ID:       appuser.ID,
+				Username: appuser.Username,
+			},
+		)
+
+	} else {
+		// create a new appuser using the fake data
+
+		u, err = f.db.GetAppuserById(f.ctx, fakeAppusers[index].ID)
+		if err == nil {
+			// if appuser exists, return it else create a new one
+			return &u
+		}
+
+		u, err = f.db.CreateAppuser(
+			f.ctx, qx.CreateAppuserParams{
+				ID:       fakeAppusers[index].ID,
+				Username: fakeAppusers[index].Username,
+			},
+		)
+	}
+
+	if err != nil {
+		t.Fatalf("Unable to create appuser. Error: %v", err)
+	}
+
+	// cache the created appuser for future use
+	fakeAppusers[index].ID = u.ID
+
+	return &u
 }
 
-// Returns a testUser that is subscribed to a server.
-func UserAppserverSub(t *testing.T) *testUser {
+func (f *Factory) Appserver(t *testing.T, index int, appserver *qx.Appserver) *qx.Appserver {
+
+	if index < 0 || index >= len(fakeAppservers) {
+		t.Fatalf("Invalid factory index: %d", index)
+	}
+
 	var (
-		u   *qx.Appuser
-		s   *qx.Appserver
-		sub *qx.AppserverSub
+		s   qx.Appserver
+		err error
 	)
-	u = testutil.TestAppuser(t, nil, true)
-	s = testutil.TestAppserver(t, nil, false)
-	sub = testutil.TestAppserverSub(t, &qx.AppserverSub{AppserverID: s.ID, AppuserID: u.ID}, false)
-	return &testUser{User: u, Server: s, Sub: sub}
+
+	if appserver != nil {
+		// with provided appserver, create using that one
+		s, err = f.db.GetAppserverById(f.ctx, appserver.ID)
+
+		if err == nil {
+			// if appserver exists, return it else create a new one
+			return &s
+		}
+
+		s, err = f.db.CreateAppserver(
+			f.ctx, qx.CreateAppserverParams{
+				Name:      appserver.Name,
+				AppuserID: appserver.AppuserID,
+			},
+		)
+
+	} else {
+		u := f.Appuser(t, index, nil)
+
+		s, err = f.db.GetAppserverById(f.ctx, fakeAppservers[index].ID)
+		if err == nil {
+			// if appserver exists, return it else create a new one
+			return &s
+		}
+
+		s, err = f.db.CreateAppserver(
+			f.ctx, qx.CreateAppserverParams{
+				Name:      fakeAppservers[index].Name,
+				AppuserID: u.ID,
+			},
+		)
+	}
+
+	if err != nil {
+		t.Fatalf("Unable to create appserver. Error: %v", err)
+	}
+
+	// cache the created appserver for future use
+	fakeAppservers[index].ID = s.ID
+
+	return &s
 }
 
-// Returns a testUser with random server sub (the server in testUser object does not match the sub's server).
-func UserAppserverUnsub(t *testing.T) *testUser {
+// AppserverSub creates or retrieves an appserver subscription by index.
+func (f *Factory) AppserverSub(t *testing.T, index int, appserverSub *qx.AppserverSub) *qx.AppserverSub {
+	if index < 0 || index >= len(fakeAppserverSubs) {
+		t.Fatalf("Invalid factory index: %d", index)
+	}
+
 	var (
-		// u   *qx.Appuser
-		u   *qx.Appuser
-		s   *qx.Appserver
-		s2  *qx.Appserver
-		sub *qx.AppserverSub
+		sub qx.AppserverSub
+		err error
 	)
-	u = testutil.TestAppuser(t, nil, false)
-	s = testutil.TestAppserver(t, nil, false)
-	s2 = testutil.TestAppserver(t, nil, false)
-	sub = testutil.TestAppserverSub(t, &qx.AppserverSub{AppserverID: s2.ID, AppuserID: u.ID}, false)
 
-	return &testUser{User: u, Server: s, Sub: sub}
+	if appserverSub != nil {
+		// with provided appserverSub, create using that one
+		sub, err = f.db.GetAppserverSubById(f.ctx, appserverSub.ID)
+
+		if err == nil {
+			// if appserverSub exists, return it else create a new one
+			return &sub
+		}
+
+		sub, err = f.db.CreateAppserverSub(
+			f.ctx, qx.CreateAppserverSubParams{
+				AppserverID: appserverSub.AppserverID,
+				AppuserID:   appserverSub.AppuserID,
+			},
+		)
+
+	} else {
+		sub, err = f.db.GetAppserverSubById(f.ctx, fakeAppserverSubs[index].ID)
+		if err == nil {
+			// if appserverSub exists, return it else create a new one
+			return &sub
+		}
+
+		s := f.Appserver(t, index, nil)
+		user := f.Appuser(t, index, nil)
+		sub, err = f.db.CreateAppserverSub(
+			f.ctx, qx.CreateAppserverSubParams{
+				AppserverID: s.ID,
+				AppuserID:   user.ID,
+			},
+		)
+	}
+
+	if err != nil {
+		t.Fatalf("Unable to create appserver sub. Error: %v", err)
+	}
+
+	// cache the created appserver sub for future use
+	fakeAppserverSubs[index].ID = sub.ID
+
+	return &sub
 }
 
-// Returns a testUser with server permission.
-func UserAppserverWithPermission(t *testing.T) *testUser {
+// AppserverRole creates or retrieves an appserver role by index.
+func (f *Factory) AppserverRole(t *testing.T, index int, appserverRole *qx.AppserverRole) *qx.AppserverRole {
+	if index < 0 || index >= len(fakeAppserverRoles) {
+		t.Fatalf("Invalid factory index: %d", index)
+	}
+
 	var (
-		u   *qx.Appuser
-		s   *qx.Appserver
-		sub *qx.AppserverSub
+		role qx.AppserverRole
+		err  error
 	)
-	u = testutil.TestAppuser(t, nil, true)
-	s = testutil.TestAppserver(t, nil, false)
-	sub = testutil.TestAppserverSub(t, &qx.AppserverSub{AppserverID: s.ID, AppuserID: u.ID}, false)
 
-	return &testUser{User: u, Server: s, Sub: sub}
+	if appserverRole != nil {
+
+		// with provided appserverRole, create using that one
+		role, err = f.db.GetAppserverRoleById(f.ctx, appserverRole.ID)
+
+		if err == nil {
+			// if appserverRole exists, return it else create a new one
+			return &role
+		}
+
+		role, err = f.db.CreateAppserverRole(
+			f.ctx, qx.CreateAppserverRoleParams{
+				Name:                    appserverRole.Name,
+				AppserverID:             appserverRole.AppserverID,
+				AppserverPermissionMask: appserverRole.AppserverPermissionMask,
+				ChannelPermissionMask:   appserverRole.ChannelPermissionMask,
+			},
+		)
+	} else {
+
+		role, err = f.db.GetAppserverRoleById(f.ctx, fakeAppserverRoles[index].ID)
+		if err == nil {
+			// if appserverRole exists, return it else create a new one
+			return &role
+		}
+
+		s := f.Appserver(t, index, nil)
+		role, err = f.db.CreateAppserverRole(
+			f.ctx, qx.CreateAppserverRoleParams{
+				Name:                    fakeAppserverRoles[index].Name,
+				AppserverID:             s.ID,
+				AppserverPermissionMask: fakeAppserverRoles[index].AppserverPermissionMask,
+				ChannelPermissionMask:   fakeAppserverRoles[index].ChannelPermissionMask,
+			},
+		)
+	}
+
+	if err != nil {
+		t.Fatalf("Unable to create appserver role. Error: %v", err)
+	}
+
+	// cache the created appserver role for future use
+	fakeAppserverRoles[index].ID = role.ID
+
+	return &role
 }
 
-// Returns a testUser with all permissions.
-func UserAppserverWithAllPermissions(t *testing.T) *testUser {
+// reate AppserverroleSub creates or retrieves an appserver role subscription by index.
+func (f *Factory) AppserverRoleSub(t *testing.T, index int, appserverRoleSub *qx.AppserverRoleSub) *qx.AppserverRoleSub {
+	if index < 0 || index >= len(fakeAppserverRoleSubs) {
+		t.Fatalf("Invalid factory index: %d", index)
+	}
+
 	var (
-		u   *qx.Appuser
-		s   *qx.Appserver
-		sub *qx.AppserverSub
-	)
-	u = testutil.TestAppuser(t, nil, true)
-	s = testutil.TestAppserver(t, nil, false)
-	sub = testutil.TestAppserverSub(t, &qx.AppserverSub{AppserverID: s.ID, AppuserID: u.ID}, false)
-
-	role := testutil.TestAppserverRole(
-		t,
-		&qx.AppserverRole{
-			AppserverID:             s.ID,
-			Name:                    "admin",
-			AppserverPermissionMask: permission.ManageAppserver | permission.ManageRoles | permission.ManageChannels,
-			ChannelPermissionMask:   0,
-			SubPermissionMask:       permission.ManageSubs,
-		},
-		false,
+		roleSub qx.AppserverRoleSub
+		err     error
 	)
 
-	testutil.TestAppserverRoleSub(t, &qx.AppserverRoleSub{
-		AppserverID:     s.ID,
-		AppuserID:       u.ID,
-		AppserverSubID:  sub.ID,
-		AppserverRoleID: role.ID,
-	}, false)
+	if appserverRoleSub != nil {
+		// with provided appserverRoleSub, create using that one
+		roleSub, err = f.db.GetAppserverRoleSubById(f.ctx, appserverRoleSub.ID)
+		if err == nil {
+			// if appserverRoleSub exists, return it else create a new one
+			return &roleSub
+		}
 
-	return &testUser{User: u, Server: s, Sub: sub}
+		roleSub, err = f.db.CreateAppserverRoleSub(
+			f.ctx, qx.CreateAppserverRoleSubParams{
+				AppserverRoleID: appserverRoleSub.AppserverRoleID,
+				AppuserID:       appserverRoleSub.AppuserID,
+				AppserverSubID:  appserverRoleSub.AppserverSubID,
+				AppserverID:     appserverRoleSub.AppserverID,
+			},
+		)
+
+	} else {
+		roleSub, err = f.db.GetAppserverRoleSubById(f.ctx, fakeAppserverRoleSubs[index].ID)
+		if err == nil {
+			// if appserverRoleSub exists, return it else create a new one
+			return &roleSub
+		}
+		s := f.Appserver(t, index, nil)
+		user := f.Appuser(t, index, nil)
+		sub := f.AppserverSub(t, index, nil)
+		role := f.AppserverRole(t, index, nil)
+		roleSub, err = f.db.CreateAppserverRoleSub(
+			f.ctx, qx.CreateAppserverRoleSubParams{
+				AppserverRoleID: role.ID,
+				AppuserID:       user.ID,
+				AppserverSubID:  sub.ID,
+				AppserverID:     s.ID,
+			},
+		)
+	}
+
+	if err != nil {
+		t.Fatalf("Unable to create appserver role sub. Error: %v", err)
+	}
+
+	// cache the created appserver role sub for future use
+	fakeAppserverRoleSubs[index].ID = roleSub.ID
+	return &roleSub
 }
 
-// func TestAppserverRole(t *testing.T, aRole *qx.AppserverRole, base bool) *qx.AppserverRole {
+// Channel creates or retrieves a channel by index.
+func (f *Factory) Channel(t *testing.T, index int, channel *qx.Channel) *qx.Channel {
+	var (
+		c   qx.Channel
+		ch  qx.Channel
+		err error
+	)
+
+	if index < 0 || index >= len(fakeChannels) {
+		t.Fatalf("Invalid factory index: %d", index)
+	}
+
+	if channel != nil {
+		// with provided channel, create using that one
+		c, err := f.db.GetChannelById(f.ctx, fakeChannels[index].ID)
+		if err == nil {
+			// if channel exists, return it else create a new one
+			return &c
+		}
+
+		ch, err = f.db.CreateChannel(
+			f.ctx, qx.CreateChannelParams{
+				Name:        channel.Name,
+				AppserverID: channel.AppserverID,
+				IsPrivate:   channel.IsPrivate,
+			},
+		)
+	} else {
+
+		c, err = f.db.GetChannelById(f.ctx, fakeChannels[index].ID)
+
+		if err == nil {
+			// if channel exists, return it else create a new one
+			return &c
+		}
+
+		s := f.Appserver(t, index, nil)
+
+		ch, err = f.db.CreateChannel(
+			f.ctx, qx.CreateChannelParams{
+				Name:        c.Name,
+				AppserverID: s.ID,
+				IsPrivate:   c.IsPrivate,
+			},
+		)
+		fakeChannels[index].ID = ch.ID
+	}
+
+	if err != nil {
+		t.Fatalf("Unable to create channel. Error: %v", err)
+	}
+
+	// cache the created channel for future use
+	fakeChannels[index].ID = ch.ID
+
+	return &ch
+}
+
+func (f *Factory) ChannelRole(t *testing.T, index int, channelRole *qx.ChannelRole) *qx.ChannelRole {
+	var (
+		cr  qx.ChannelRole
+		err error
+	)
+
+	if index < 0 || index >= len(fakeChannelRoles) {
+		t.Fatalf("Invalid factory index: %d", index)
+	}
+
+	if channelRole != nil {
+		// with provided channelRole, create using that one
+		cr, err = f.db.GetChannelRoleById(f.ctx, channelRole.ID)
+		if err == nil {
+			// if channelRole exists, return it else create a new one
+			return &cr
+		}
+
+		cr, err = f.db.CreateChannelRole(
+			f.ctx, qx.CreateChannelRoleParams{
+				ChannelID:       channelRole.ChannelID,
+				AppserverID:     channelRole.AppserverID,
+				AppserverRoleID: channelRole.AppserverRoleID,
+			},
+		)
+	} else {
+
+		cr, err = f.db.GetChannelRoleById(f.ctx, fakeChannelRoles[index].ID)
+
+		if err == nil {
+			// if channel exists, return it else create a new one
+			return &cr
+		}
+
+		s := f.Appserver(t, index, nil)
+		ch := f.Channel(t, index, nil)
+		role := f.AppserverRole(t, index, nil)
+
+		cr, err = f.db.CreateChannelRole(
+			f.ctx, qx.CreateChannelRoleParams{
+				ChannelID:       ch.ID,
+				AppserverID:     s.ID,
+				AppserverRoleID: role.ID,
+			},
+		)
+	}
+
+	if err != nil {
+		t.Fatalf("Unable to create channel role. Error: %v", err)
+	}
+
+	fakeChannelRoles[index].ID = cr.ID
+
+	return &cr
+}

--- a/src/testutil/factory/factory.go
+++ b/src/testutil/factory/factory.go
@@ -207,6 +207,7 @@ func (f *Factory) AppserverRole(t *testing.T, index int, appserverRole *qx.Appse
 				AppserverID:             appserverRole.AppserverID,
 				AppserverPermissionMask: appserverRole.AppserverPermissionMask,
 				ChannelPermissionMask:   appserverRole.ChannelPermissionMask,
+				SubPermissionMask:       appserverRole.SubPermissionMask,
 			},
 		)
 	} else {
@@ -224,6 +225,7 @@ func (f *Factory) AppserverRole(t *testing.T, index int, appserverRole *qx.Appse
 				AppserverID:             s.ID,
 				AppserverPermissionMask: fakeAppserverRoles[index].AppserverPermissionMask,
 				ChannelPermissionMask:   fakeAppserverRoles[index].ChannelPermissionMask,
+				SubPermissionMask:       fakeAppserverRoles[index].SubPermissionMask,
 			},
 		)
 	}

--- a/src/testutil/factory/fake_db.go
+++ b/src/testutil/factory/fake_db.go
@@ -1,0 +1,74 @@
+package factory
+
+import (
+	"mist/src/psql_db/qx"
+	"mist/src/testutil"
+
+	"github.com/google/uuid"
+)
+
+var (
+
+	// fake appusers
+	fakeAppusers = []*qx.Appuser{
+		{ID: uuid.MustParse("874fb22c-8e3a-4504-9a4b-437c22655865"), Username: "testuser0"},
+		{ID: uuid.MustParse("874fb22c-8e3a-4504-9a4b-437c22655866"), Username: "testuser1"},
+		{ID: uuid.MustParse("874fb22c-8e3a-4504-9a4b-437c22655867"), Username: "testuser2"},
+		{ID: uuid.MustParse("874fb22c-8e3a-4504-9a4b-437c22655868"), Username: "testuser3"},
+		{ID: uuid.MustParse("874fb22c-8e3a-4504-9a4b-437c22655869"), Username: "testuser4"},
+	}
+
+	// fake appservers
+	fakeAppservers = []*qx.Appserver{
+		{Name: "testserver0", AppuserID: uuid.MustParse(testutil.DefaultUserId)},
+		{Name: "testserver1", AppuserID: uuid.MustParse(testutil.DefaultUserId)},
+		{Name: "testserver2", AppuserID: uuid.MustParse(testutil.DefaultUserId)},
+		{Name: "testserver3", AppuserID: uuid.MustParse(testutil.DefaultUserId)},
+		{Name: "testserver4", AppuserID: uuid.MustParse(testutil.DefaultUserId)},
+	}
+
+	// fake appserver subs
+	fakeAppserverSubs = []*qx.AppserverSub{
+		{ID: uuid.New()},
+		{ID: uuid.New()},
+		{ID: uuid.New()},
+		{ID: uuid.New()},
+		{ID: uuid.New()},
+	}
+
+	// fake appserver roles
+	fakeAppserverRoles = []*qx.AppserverRole{
+		{ID: uuid.New(), Name: "role0", AppserverPermissionMask: int64(0), ChannelPermissionMask: int64(0), SubPermissionMask: int64(0)},
+		{ID: uuid.New(), Name: "role1", AppserverPermissionMask: int64(0), ChannelPermissionMask: int64(0), SubPermissionMask: int64(0)},
+		{ID: uuid.New(), Name: "role2", AppserverPermissionMask: int64(0), ChannelPermissionMask: int64(0), SubPermissionMask: int64(0)},
+		{ID: uuid.New(), Name: "role3", AppserverPermissionMask: int64(0), ChannelPermissionMask: int64(0), SubPermissionMask: int64(0)},
+		{ID: uuid.New(), Name: "role4", AppserverPermissionMask: int64(0), ChannelPermissionMask: int64(0), SubPermissionMask: int64(0)},
+	}
+
+	// fake appserver role subs
+	fakeAppserverRoleSubs = []*qx.AppserverRoleSub{
+		{ID: uuid.New()},
+		{ID: uuid.New()},
+		{ID: uuid.New()},
+		{ID: uuid.New()},
+		{ID: uuid.New()},
+	}
+
+	// fake channels
+	fakeChannels = []*qx.Channel{
+		{ID: uuid.New(), Name: "testchannel0", IsPrivate: false},
+		{ID: uuid.New(), Name: "testchannel1", IsPrivate: true},
+		{ID: uuid.New(), Name: "testchannel2", IsPrivate: false},
+		{ID: uuid.New(), Name: "testchannel3", IsPrivate: true},
+		{ID: uuid.New(), Name: "testchannel4", IsPrivate: false},
+	}
+
+	// fake channel roles
+	fakeChannelRoles = []*qx.ChannelRole{
+		{ID: uuid.New()},
+		{ID: uuid.New()},
+		{ID: uuid.New()},
+		{ID: uuid.New()},
+		{ID: uuid.New()},
+	}
+)

--- a/src/testutil/factory/templates.go
+++ b/src/testutil/factory/templates.go
@@ -1,0 +1,131 @@
+package factory
+
+import (
+	"context"
+	"mist/src/permission"
+	"mist/src/psql_db/db"
+	"mist/src/psql_db/qx"
+	"mist/src/testutil"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+type testUser struct {
+	User   *qx.Appuser
+	Server *qx.Appserver
+	Sub    *qx.AppserverSub
+}
+
+func UserAppserverOwner(t *testing.T, ctx context.Context, db db.Querier) *testUser {
+	var (
+		u   *qx.Appuser
+		s   *qx.Appserver
+		sub *qx.AppserverSub
+	)
+
+	f := NewFactory(ctx, db)
+
+	parsedUid, err := uuid.Parse(ctx.Value(testutil.CtxUserKey).(string))
+
+	if err != nil {
+		t.Fatalf("failed to parse user ID from context: %v", err)
+	}
+
+	u = f.Appuser(t, 0, &qx.Appuser{ID: parsedUid, Username: "testuser"})
+	s = f.Appserver(t, 0, &qx.Appserver{Name: "testserver", AppuserID: u.ID})
+	sub = f.AppserverSub(t, 0, &qx.AppserverSub{AppserverID: s.ID, AppuserID: u.ID})
+
+	return &testUser{User: u, Server: s, Sub: sub}
+}
+
+// Returns a testUser that is subscribed to a server.
+func UserAppserverSub(t *testing.T, ctx context.Context, db db.Querier) *testUser {
+	var (
+		u   *qx.Appuser
+		s   *qx.Appserver
+		sub *qx.AppserverSub
+	)
+	f := NewFactory(ctx, db)
+
+	parsedUid, err := uuid.Parse(ctx.Value(testutil.CtxUserKey).(string))
+
+	if err != nil {
+		t.Fatalf("failed to parse user ID from context: %v", err)
+	}
+
+	u = f.Appuser(t, 0, &qx.Appuser{ID: parsedUid, Username: "testuser"})
+	s = f.Appserver(t, 0, nil)
+	sub = f.AppserverSub(t, 0, nil)
+
+	return &testUser{User: u, Server: s, Sub: sub}
+}
+
+// Returns a testUser with random server sub (the server in testUser object does not match the sub's server).
+func UserAppserverUnsub(t *testing.T, ctx context.Context, db db.Querier) *testUser {
+	var (
+		// u   *qx.Appuser
+		u   *qx.Appuser
+		s   *qx.Appserver
+		s1  *qx.Appserver
+		sub *qx.AppserverSub
+	)
+
+	f := NewFactory(ctx, db)
+	parsedUid, err := uuid.Parse(ctx.Value(testutil.CtxUserKey).(string))
+
+	if err != nil {
+		t.Fatalf("failed to parse user ID from context: %v", err)
+	}
+
+	u = f.Appuser(t, 0, &qx.Appuser{ID: parsedUid, Username: "testuser"})
+	owner := f.Appuser(t, 1, &qx.Appuser{ID: uuid.New(), Username: "owner"})
+	s = f.Appserver(t, 0, nil)
+	s1 = f.Appserver(t, 1, nil)
+	sub = f.AppserverSub(t, 0, &qx.AppserverSub{AppserverID: s1.ID, AppuserID: owner.ID})
+
+	return &testUser{User: u, Server: s, Sub: sub}
+}
+
+// Returns a testUser with all permissions.
+func UserAppserverWithAllPermissions(t *testing.T, ctx context.Context, db db.Querier) *testUser {
+	var (
+		u   *qx.Appuser
+		s   *qx.Appserver
+		sub *qx.AppserverSub
+	)
+
+	f := NewFactory(ctx, db)
+
+	// Create a user, server and subscription
+	parsedUid, err := uuid.Parse(ctx.Value(testutil.CtxUserKey).(string))
+
+	if err != nil {
+		t.Fatalf("failed to parse user ID from context: %v", err)
+	}
+
+	u = f.Appuser(t, 0, &qx.Appuser{ID: parsedUid, Username: "testuser"})
+	s = f.Appserver(t, 0, nil)
+	sub = f.AppserverSub(t, 0, &qx.AppserverSub{AppserverID: s.ID, AppuserID: u.ID})
+
+	role := f.AppserverRole(
+		t,
+		0,
+		&qx.AppserverRole{
+			AppserverID:             s.ID,
+			Name:                    "admin",
+			AppserverPermissionMask: permission.ManageAppserver | permission.ManageRoles | permission.ManageChannels,
+			ChannelPermissionMask:   0,
+			SubPermissionMask:       permission.ManageSubs,
+		},
+	)
+
+	f.AppserverRoleSub(t, 0, &qx.AppserverRoleSub{
+		AppserverID:     s.ID,
+		AppuserID:       u.ID,
+		AppserverSubID:  sub.ID,
+		AppserverRoleID: role.ID,
+	})
+
+	return &testUser{User: u, Server: s, Sub: sub}
+}

--- a/src/testutil/testutil.go
+++ b/src/testutil/testutil.go
@@ -32,7 +32,6 @@ import (
 	"mist/src/protos/v1/channel"
 	"mist/src/protos/v1/channel_role"
 	"mist/src/psql_db/db"
-	"mist/src/psql_db/qx"
 	"mist/src/rpcs"
 )
 
@@ -186,7 +185,6 @@ func Setup(t *testing.T, cleanup func()) (context.Context, db.Querier) {
 
 	t.Cleanup(func() {
 		q.Rollback(ctx)
-		teardown(ctx)
 		cleanup()
 		cancel()
 	})
@@ -209,28 +207,6 @@ func Setup(t *testing.T, cleanup func()) (context.Context, db.Querier) {
 	ctx = context.WithValue(ctx, middleware.JwtClaimsK, claims)
 
 	return ctx, q
-}
-
-func teardown(ctx context.Context) {
-	// Cleans all the table's data after each test (used in setup) function
-	tables := []string{
-		"appserver",
-		"appuser",
-		"appserver_sub",
-		"appserver_role",
-		"appserver_role_sub",
-		"channel",
-		"channel_role",
-	}
-
-	for _, table := range tables {
-		query := fmt.Sprintf(`TRUNCATE TABLE %s RESTART IDENTITY CASCADE;`, table)
-
-		if _, err := TestDbConn.Exec(ctx, query); err != nil {
-			// add calee to the log message for better debugging
-			log.Printf("Failed to truncate table %s: %v", table, err)
-		}
-	}
 }
 
 // ----- HELPER FUNCTIONS -----
@@ -265,202 +241,4 @@ func CreateJwtToken(t *testing.T, params *CreateTokenParams) (string, *middlewar
 		t.Fatalf("error signing the token %v", err)
 	}
 	return token, c
-}
-
-// ----- DB HELPER FUNCTIONS -----
-func TestAppuser(t *testing.T, appuser *qx.Appuser, base bool) *qx.Appuser {
-	var (
-		id   uuid.UUID
-		user qx.Appuser
-		err  error
-	)
-	ctx := context.Background()
-	q := qx.New(TestDbConn)
-
-	if appuser == nil {
-		// Default values
-		if base {
-			id = uuid.MustParse(DefaultUserId)
-			user, err = q.GetAppuserById(ctx, id)
-
-			// if user already exists, return it
-			if err == nil {
-				return &user
-			}
-
-		} else {
-			id, _ = uuid.NewUUID()
-		}
-		appuser = &qx.Appuser{
-			ID:       id,
-			Username: uuid.NewString(),
-		}
-	}
-
-	user, err = q.CreateAppuser(ctx, qx.CreateAppuserParams{
-		ID:       appuser.ID,
-		Username: appuser.Username,
-	})
-
-	if err != nil {
-		t.Fatalf("Unable to create appserver. Error: %v", err)
-	}
-
-	return &user
-}
-
-func TestAppserver(t *testing.T, appserver *qx.Appserver, base bool) *qx.Appserver {
-
-	if appserver == nil {
-		// Custom values
-		appserver = &qx.Appserver{
-			AppuserID: TestAppuser(t, nil, base).ID,
-			Name:      uuid.NewString(),
-		}
-	}
-
-	as, err := qx.New(TestDbConn).CreateAppserver(context.Background(), qx.CreateAppserverParams{
-		AppuserID: appserver.AppuserID,
-		Name:      appserver.Name,
-	})
-
-	if err != nil {
-		t.Fatalf("Unable to create appserver. Error: %v", err)
-	}
-
-	return &as
-}
-
-func TestAppserverRole(t *testing.T, aRole *qx.AppserverRole, base bool) *qx.AppserverRole {
-	// Define attributes
-
-	if aRole == nil {
-		aRole = &qx.AppserverRole{
-			AppserverID:             TestAppserver(t, nil, base).ID,
-			Name:                    uuid.NewString(),
-			AppserverPermissionMask: 0,
-			ChannelPermissionMask:   0,
-			SubPermissionMask:       0,
-		}
-	}
-
-	asRole, err := qx.New(TestDbConn).CreateAppserverRole(
-		context.Background(),
-		qx.CreateAppserverRoleParams{
-			AppserverID:             aRole.AppserverID,
-			Name:                    aRole.Name,
-			AppserverPermissionMask: aRole.AppserverPermissionMask,
-			ChannelPermissionMask:   aRole.ChannelPermissionMask,
-			SubPermissionMask:       aRole.SubPermissionMask,
-		},
-	)
-
-	if err != nil {
-		t.Fatalf("Unable to create appserverRole. Error: %v", err)
-	}
-
-	return &asRole
-}
-
-func TestAppserverRoleSub(t *testing.T, roleSub *qx.AppserverRoleSub, base bool) *qx.AppserverRoleSub {
-	// Define attributes
-
-	if roleSub == nil {
-		// Custom values
-		user := TestAppuser(t, nil, base)
-		appserver := TestAppserver(t, nil, base)
-		sub := TestAppserverSub(t, &qx.AppserverSub{AppserverID: appserver.ID, AppuserID: user.ID}, base)
-		role := TestAppserverRole(t, &qx.AppserverRole{Name: uuid.NewString(), AppserverID: appserver.ID}, base)
-		roleSub = &qx.AppserverRoleSub{
-			AppserverRoleID: role.ID,
-			AppserverSubID:  sub.ID,
-			AppserverID:     appserver.ID,
-			AppuserID:       user.ID,
-		}
-	}
-
-	asrSub, err := qx.New(TestDbConn).CreateAppserverRoleSub(
-		context.Background(),
-		qx.CreateAppserverRoleSubParams{
-			AppserverRoleID: roleSub.AppserverRoleID,
-			AppserverSubID:  roleSub.AppserverSubID,
-			AppuserID:       roleSub.AppuserID,
-			AppserverID:     roleSub.AppserverID,
-		},
-	)
-
-	if err != nil {
-		t.Fatalf("Unable to create appserverRole. Error: %v", err)
-	}
-
-	return &asrSub
-}
-
-func TestAppserverSub(t *testing.T, aSub *qx.AppserverSub, base bool) *qx.AppserverSub {
-	// Define attributes
-
-	if aSub == nil {
-		appuser := TestAppuser(t, nil, base)
-		appserver := TestAppserver(t, nil, base)
-		aSub = &qx.AppserverSub{
-			AppserverID: appserver.ID,
-			AppuserID:   appuser.ID,
-		}
-	}
-
-	asSub, err := qx.New(TestDbConn).CreateAppserverSub(
-		context.Background(),
-		qx.CreateAppserverSubParams{AppserverID: aSub.AppserverID, AppuserID: aSub.AppuserID},
-	)
-
-	if err != nil {
-		t.Fatalf("Unable to create appserverSub. Error: %v", err)
-	}
-
-	return &asSub
-}
-
-func TestChannel(t *testing.T, c *qx.Channel, base bool) *qx.Channel {
-	// Define attributes
-
-	if c == nil {
-		// Default value
-		c = &qx.Channel{
-			Name:        uuid.NewString(),
-			AppserverID: TestAppserver(t, nil, base).ID,
-			IsPrivate:   false,
-		}
-	}
-
-	channel, err := qx.New(TestDbConn).CreateChannel(
-		context.Background(), qx.CreateChannelParams{Name: c.Name, AppserverID: c.AppserverID, IsPrivate: c.IsPrivate})
-
-	if err != nil {
-		t.Fatalf("Unable to create appserver. Error: %v", err)
-	}
-	return &channel
-}
-
-func TestChannelRole(t *testing.T, cr *qx.ChannelRole, base bool) *qx.ChannelRole {
-	// Define attributes
-
-	if cr == nil {
-		// Default value
-		role := TestAppserverRole(t, nil, base)
-		cr = &qx.ChannelRole{
-			AppserverID:     role.AppserverID,
-			AppserverRoleID: role.ID,
-			ChannelID:       TestChannel(t, &qx.Channel{Name: uuid.NewString(), AppserverID: role.AppserverID}, base).ID,
-		}
-	}
-
-	role, err := qx.New(TestDbConn).CreateChannelRole(
-		context.Background(),
-		qx.CreateChannelRoleParams{AppserverRoleID: cr.AppserverRoleID, ChannelID: cr.ChannelID, AppserverID: cr.AppserverID},
-	)
-
-	if err != nil {
-		t.Fatalf("Unable to create appserver. Error: %v", err)
-	}
-	return &role
 }


### PR DESCRIPTION
## What changed
* Replacement of using global db connection in tests with teardown procedure (truncate tables) to use transactions instead
* Entire app needed changes since it involved changing how the dependency for db was injected. Should be simpler now to inject since theres less dependencies.